### PR TITLE
BUG: preop label selector still did only hold vtkMRMLScalarVolumeNode…

### DIFF
--- a/RegistrationModule/RegistrationModule.py
+++ b/RegistrationModule/RegistrationModule.py
@@ -454,8 +454,7 @@ class RegistrationModuleWidget(ScriptedLoadableModuleWidget):
 
     # preop label selector
     self.preopLabelSelector = slicer.qMRMLNodeComboBox()
-    self.preopLabelSelector.nodeTypes = ( ("vtkMRMLScalarVolumeNode"), "" )
-    self.preopLabelSelector.addAttribute( "vtkMRMLScalarVolumeNode", "LabelMap", 1 )
+    self.preopLabelSelector.nodeTypes = ( ("vtkMRMLLabelMapVolumeNode"), "" )
     self.preopLabelSelector.selectNodeUponCreation = False
     self.preopLabelSelector.addEnabled = False
     self.preopLabelSelector.removeEnabled = False


### PR DESCRIPTION
… instead of vtkMRMLLabelMapVolumeNode

- this resulted in bad registration since there was no proper label volume selected