### PR TITLE
Add chart widget for target displacement tracking

### DIFF
--- a/SliceTracker/SliceTracker.py
+++ b/SliceTracker/SliceTracker.py
@@ -3661,7 +3661,7 @@ class TargetDisplacementChartWidget(object):
     self._chartView = ctk.ctkVTKChartView()
     self._chartView.minimumSize = qt.QSize(200, 200)
     self._showLegend = False
-    self.xAxis.SetTitle('Time Unit')
+    self.xAxis.SetTitle('Timepoint')
     self.yAxis.SetTitle('Displacement')
     self.chartTable = vtk.vtkTable()
 
@@ -3735,6 +3735,16 @@ class TargetDisplacementChartWidget(object):
       distance = (triplets[i][0] ** 2 + triplets[i][1] ** 2 + triplets[i][2] ** 2) ** 0.5
       self.arrD.InsertNextValue(distance)
 
+    xvals = vtk.vtkDoubleArray()
+    xlabels = vtk.vtkStringArray()
+    maxX = self.arrX.GetNumberOfValues() - 2
+    for j in range(0, maxX + 1):
+      xvals.InsertNextValue(j)
+      xlabels.InsertNextValue(str(j))
+    self.xAxis.SetCustomTickPositions(xvals, xlabels)
+    self.xAxis.SetBehavior(vtk.vtkAxis.FIXED)
+    self.xAxis.SetRange(0, maxX + 0.1)
+
     plot = self.chart.AddPlot(vtk.vtkChart.LINE)
     plot.SetInputData(self.chartTable, 0, 1)
     plot.SetColor(255, 0, 0, 255)
@@ -3772,8 +3782,10 @@ class TargetDisplacementChartWidget(object):
   def onShowLegendChanged(self, checked):
     if checked == 2:
       self.chart.SetShowLegend(True)
+      self.chartView.scene().SetDirty(True)
     else:
       self.chart.SetShowLegend(False)
+      self.chartView.scene().SetDirty(True)
 
   def onDockChartViewToggled(self, checked):
     if checked:

--- a/SliceTracker/SliceTracker.py
+++ b/SliceTracker/SliceTracker.py
@@ -1,6 +1,6 @@
 import csv, re, numpy, json, ast, re
 import shutil, datetime, logging
-import ctk, vtk, qt, PythonQt
+import ctk, vtk, qt
 from collections import OrderedDict
 
 import SimpleITK as sitk
@@ -3696,7 +3696,7 @@ class TargetDisplacementChartWidget(object):
   def onDockChartViewToggled(self,checked):
     if checked:
       self.chartPopupWindow = qt.QDialog()
-      self.chartPopupWindow.setWindowFlags(PythonQt.QtCore.Qt.WindowStaysOnTopHint)
+      self.chartPopupWindow.setWindowFlags(qt.Qt.WindowStaysOnTopHint)
       layout = qt.QGridLayout()
       self.chartPopupWindow.setLayout(layout)
       layout.addWidget(self._chartView)

--- a/SliceTracker/SliceTracker.py
+++ b/SliceTracker/SliceTracker.py
@@ -279,8 +279,8 @@ class SliceTrackerWidget(ModuleWidgetMixin, SliceTrackerConstants, ScriptedLoada
     self.trackTargetsButton.setEnabled(False)
     self.currentTargets = None
     self.updateDisplacementChartTargetSelectorTable()
-    self.targetDisplacementChart.resetAndInitializeChart()
     self.targetDisplacementChart.lastSelectedTarget = None
+    self.targetDisplacementChart.resetAndInitializeChart()
     self.resetViewSettingButtons()
     self.resetVisualEffects()
     self.disconnectKeyEventObservers()
@@ -3741,9 +3741,12 @@ class TargetDisplacementChartWidget(object):
     for i in range(0, len(triplets)):
       if numCurrentRows == 0:
         self._chartView.hide()
+        self.showLegendCheckBox.hide()
         self.arrX.InsertNextValue(0)
       else:
         self._chartView.show()
+        if not self.showLegendCheckBox.isVisible():
+          self.showLegendCheckBox.show()
         self.arrX.InsertNextValue(numCurrentRows + i - 1)
       self.arrXD.InsertNextValue(triplets[i][0])
       self.arrYD.InsertNextValue(triplets[i][1])
@@ -3792,7 +3795,7 @@ class TargetDisplacementChartWidget(object):
     self.arrZD.Initialize()
     self.arrD.Initialize()
     self.addPlotPoints([[0, 0, 0], [0, 0, 0]])
-    if self.showLegendCheckBox.isChecked():
+    if self.showLegendCheckBox.isChecked() and self.lastSelectedTarget is None:
       self.showLegendCheckBox.setChecked(False)
 
   def onShowLegendChanged(self, checked):
@@ -3808,6 +3811,7 @@ class TargetDisplacementChartWidget(object):
       self.chartPopupWindow.setLayout(layout)
       targetLayout = qt.QFormLayout()
       targetLayout.addRow("Target:", self.DisplacementChartTargetSelector)
+      targetLayout.addRow(self.showLegendCheckBox)
       layout.addLayout(targetLayout, 1, 0)
       layout.addWidget(self._chartView, 2, 0)
       child = self.targetSelectorLayout.takeAt(0)
@@ -3824,6 +3828,7 @@ class TargetDisplacementChartWidget(object):
   def dockChartView(self):
     self.chartPopupSize = self.chartPopupWindow.size
     self.chartPopupPosition = self.chartPopupWindow.pos
+    self.plottingFrameLayout.addWidget(self.showLegendCheckBox, 1, 0)
     self.plottingFrameLayout.addWidget(self._chartView, 2, 0)
     self.plottingFrameLayout.addWidget(self.popupChartButton, 3, 0)
     self.targetSelectorLayout.insertRow(0, "Target:", self.DisplacementChartTargetSelector)

--- a/SliceTracker/SliceTracker.py
+++ b/SliceTracker/SliceTracker.py
@@ -3580,6 +3580,7 @@ class NewCaseSelectionNameWidget(qt.QMessageBox, ModuleWidgetMixin):
     self.okButton.enabled = not os.path.exists(self.newCaseDirectory)
     self.notice.text = "" if not os.path.exists(self.newCaseDirectory) else "Note: Directory already exists."
 
+
 class TargetDisplacementChartWidget(object):
     
   @property
@@ -3614,8 +3615,6 @@ class TargetDisplacementChartWidget(object):
     self._showLegend = False
     self.xAxis.SetTitle('Time Unit')
     self.yAxis.SetTitle('Displacement')
-    
-    
     self.chartTable = vtk.vtkTable()
 
     self.arrX = vtk.vtkFloatArray()
@@ -3655,7 +3654,6 @@ class TargetDisplacementChartWidget(object):
     self.popupChartButton = qt.QPushButton("Undock chart")
     self.popupChartButton.setCheckable(True)
     self.plottingFrameLayout.addWidget(self.popupChartButton)
-
     plotFrameLayout.addWidget(self.plottingFrameWidget)
 
     self.popupChartButton.connect('toggled(bool)', self.onDockChartViewToggled)
@@ -3668,7 +3666,6 @@ class TargetDisplacementChartWidget(object):
       self.arrXD.InsertNextValue(triplets[i][0])
       self.arrYD.InsertNextValue(triplets[i][1])
       self.arrZD.InsertNextValue(triplets[i][2])
-
     self.chartTable.AddColumn(self.arrX)
     self.chartTable.AddColumn(self.arrXD)
     self.chartTable.AddColumn(self.arrYD)
@@ -3685,7 +3682,6 @@ class TargetDisplacementChartWidget(object):
     plot3 = self.chart.AddPlot(vtk.vtkChart.LINE)
     plot3.SetInputData(self.chartTable,0,3)
     plot3.SetColor(0,0,255,255)
-
 
   def onShowLegendChanged(self, checked):
     if checked == 2:


### PR DESCRIPTION
fixes #84. Added the chart widget, currently to the overviewGroupBox layout. The addPlotPoints function can currently only handle one target (x,y,z) position data, in the form of a list of lists.