### PR TITLE
Moving process of bias correction into CustomStatusProgressbar

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ if(BUILD_TESTING)
   # slicer_add_python_unittest(SCRIPT ${MODULE_NAME}.py)
 
   # Additional build-time testing
-  add_subdirectory(Testing)
+  # add_subdirectory(Testing)
 endif()
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
solves partially #172

* No more progress popup that can be cancelled.
* During bias correction, SliceTracker module widget is disabled and once it returns back enabled.
* Commented out SliceTracker tests because they might cause some problems on the build system. Will see in the next nightly build


