### PR TITLE
ENH: added TargetSelectionEvent to session (issue #284):

### DIFF
--- a/SliceTracker/SliceTrackerUtils/session.py
+++ b/SliceTracker/SliceTrackerUtils/session.py
@@ -187,8 +187,8 @@ class SliceTrackerSession(StepBasedSession):
       self.data.initialLabel = value
     self._fixedLabel = value
 
-  def setSelectedTarget(self, targetListId, index):
-    self.invokeEvent(self.TargetSelectionEvent, str([targetListId, index]))
+  def setSelectedTarget(self, targetListId, info):
+    self.invokeEvent(self.TargetSelectionEvent, str([targetListId, info]))
 
   def __init__(self):
     StepBasedSession.__init__(self)

--- a/SliceTracker/SliceTrackerUtils/session.py
+++ b/SliceTracker/SliceTrackerUtils/session.py
@@ -187,8 +187,8 @@ class SliceTrackerSession(StepBasedSession):
       self.data.initialLabel = value
     self._fixedLabel = value
 
-  def setSelectedTarget(self, targetListId, info):
-    self.invokeEvent(self.TargetSelectionEvent, str([targetListId, info]))
+  def setSelectedTarget(self, info):
+    self.invokeEvent(self.TargetSelectionEvent, str(info))
 
   def __init__(self):
     StepBasedSession.__init__(self)

--- a/SliceTracker/SliceTrackerUtils/steps/overview.py
+++ b/SliceTracker/SliceTrackerUtils/steps/overview.py
@@ -165,8 +165,6 @@ class SliceTrackerOverviewStep(SliceTrackerStep):
       if not self.session.data.registrationResultWasSkipped(selectedSeries):
         self.regResultsPlugin.cleanup()
 
-      self.targetTablePlugin.currentTargets = None
-
       if self.session.seriesTypeManager.isVibe(selectedSeries):
         volume = self.session.getOrCreateVolumeForSeries(selectedSeries)
         self.setupFourUpView(volume)
@@ -174,6 +172,10 @@ class SliceTrackerOverviewStep(SliceTrackerStep):
         if result:
           self.targetTablePlugin.currentTargets = result.targets.approved
           self.regResultsPlugin.showIntraopTargets(result.targets.approved)
+        else:
+          self.targetTablePlugin.currentTargets = None
+      else:
+        self.targetTablePlugin.currentTargets = None
 
   def setIntraopSeriesButtons(self, trackingPossible, selectedSeries):
     trackingPossible = trackingPossible and not self.session.data.completed

--- a/SliceTracker/SliceTrackerUtils/steps/plugins/targets.py
+++ b/SliceTracker/SliceTrackerUtils/steps/plugins/targets.py
@@ -313,6 +313,7 @@ class SliceTrackerTargetTablePlugin(SliceTrackerPlugin):
     self.targetTableModel.targetList = targets
     if not targets:
       self.targetTableModel.coverProstateTargetList = None
+      self.session.setSelectedTarget(None, -1)
     else:
       coverProstate = self.session.data.getMostRecentApprovedCoverProstateRegistration()
       if coverProstate:

--- a/SliceTracker/SliceTrackerUtils/steps/plugins/targets.py
+++ b/SliceTracker/SliceTrackerUtils/steps/plugins/targets.py
@@ -281,17 +281,10 @@ class SliceTrackerTargetTableLogic(SliceTrackerLogicBase):
 
 class SliceTrackerTargetTablePlugin(SliceTrackerPlugin):
 
+  lastSelectedModelIndex = None
+
   NAME = "TargetTable"
   LogicClass = SliceTrackerTargetTableLogic
-
-  @property
-  def lastSelectedModelIndex(self):
-    return self.session.lastSelectedModelIndex
-
-  @lastSelectedModelIndex.setter
-  def lastSelectedModelIndex(self, modelIndex):
-    assert self.currentTargets is not None
-    self.session.lastSelectedModelIndex = modelIndex
 
   @property
   def movingEnabled(self):
@@ -423,19 +416,18 @@ class SliceTrackerTargetTablePlugin(SliceTrackerPlugin):
     self.targetTableModel.cursorPosition = ras
 
   def onTargetSelectionChanged(self, modelIndex=None):
-    # onCurrentResultSelected event
     if not modelIndex:
       self.getAndSelectTargetFromTable()
       return
     if self.moveTargetMode is True and modelIndex != self.currentlyMovedTargetModelIndex:
       self.disableTargetMovingMode()
     self.lastSelectedModelIndex = modelIndex
+    self.session.setSelectedTarget(self.currentTargets.GetID(), modelIndex.row())
     if not self.currentTargets:
       self.currentTargets = self.session.data.initialTargets
     self.jumpSliceNodesToNthTarget(modelIndex.row())
-    # self.updateNeedleModel()
-    self.targetTableModel.currentTargetIndex = self.lastSelectedModelIndex.row()
-    self.updateSelection(self.lastSelectedModelIndex.row())
+    self.targetTableModel.currentTargetIndex = modelIndex
+    self.updateSelection(modelIndex.row())
 
   def updateSelection(self, row):
     self.targetTable.clearSelection()

--- a/SliceTracker/SliceTrackerUtils/steps/plugins/targets.py
+++ b/SliceTracker/SliceTrackerUtils/steps/plugins/targets.py
@@ -313,7 +313,7 @@ class SliceTrackerTargetTablePlugin(SliceTrackerPlugin):
     self.targetTableModel.targetList = targets
     if not targets:
       self.targetTableModel.coverProstateTargetList = None
-      self.session.setSelectedTarget(None, self.getCurrentTargetInfo())
+      self.session.setSelectedTarget(self.getCurrentTargetInfo())
     else:
       coverProstate = self.session.data.getMostRecentApprovedCoverProstateRegistration()
       if coverProstate:
@@ -324,11 +324,12 @@ class SliceTrackerTargetTablePlugin(SliceTrackerPlugin):
 
   def getCurrentTargetInfo(self):
     if not self._currentTargets:
-      return {'index': -1, 'hole': None, 'depth': None}
+      return {'nodeId': None, 'index': -1, 'hole': None, 'depth': None}
     else:
       guidance = self.targetTableModel.getOrCreateNewGuidanceComputation(self._currentTargets)
       index = self.lastSelectedModelIndex.row()
-      return {'index': index, 'hole': guidance.getZFrameHole(index), 'depth': guidance.getZFrameDepth(index)}
+      return {'nodeId': self._currentTargets.GetID(), 'index': index, 'hole': guidance.getZFrameHole(index),
+              'depth': guidance.getZFrameDepth(index)}
 
   def __init__(self, **kwargs):
     super(SliceTrackerTargetTablePlugin, self).__init__()
@@ -431,7 +432,7 @@ class SliceTrackerTargetTablePlugin(SliceTrackerPlugin):
     if self.moveTargetMode is True and modelIndex != self.currentlyMovedTargetModelIndex:
       self.disableTargetMovingMode()
     self.lastSelectedModelIndex = modelIndex
-    self.session.setSelectedTarget(self.currentTargets.GetID(), self.getCurrentTargetInfo())
+    self.session.setSelectedTarget(self.getCurrentTargetInfo())
     if not self.currentTargets:
       self.currentTargets = self.session.data.initialTargets
     self.jumpSliceNodesToNthTarget(modelIndex.row())

--- a/SliceTracker/SliceTrackerUtils/steps/plugins/targets.py
+++ b/SliceTracker/SliceTrackerUtils/steps/plugins/targets.py
@@ -313,7 +313,7 @@ class SliceTrackerTargetTablePlugin(SliceTrackerPlugin):
     self.targetTableModel.targetList = targets
     if not targets:
       self.targetTableModel.coverProstateTargetList = None
-      self.session.setSelectedTarget(None, -1)
+      self.session.setSelectedTarget(None, self.getCurrentTargetInfo())
     else:
       coverProstate = self.session.data.getMostRecentApprovedCoverProstateRegistration()
       if coverProstate:
@@ -321,6 +321,14 @@ class SliceTrackerTargetTablePlugin(SliceTrackerPlugin):
     self.targetTable.enabled = targets is not None
     if self.currentTargets:
       self.onTargetSelectionChanged()
+
+  def getCurrentTargetInfo(self):
+    if not self._currentTargets:
+      return {'index': -1, 'hole': None, 'depth': None}
+    else:
+      guidance = self.targetTableModel.getOrCreateNewGuidanceComputation(self._currentTargets)
+      index = self.lastSelectedModelIndex.row()
+      return {'index': index, 'hole': guidance.getZFrameHole(index), 'depth': guidance.getZFrameDepth(index)}
 
   def __init__(self, **kwargs):
     super(SliceTrackerTargetTablePlugin, self).__init__()
@@ -423,7 +431,7 @@ class SliceTrackerTargetTablePlugin(SliceTrackerPlugin):
     if self.moveTargetMode is True and modelIndex != self.currentlyMovedTargetModelIndex:
       self.disableTargetMovingMode()
     self.lastSelectedModelIndex = modelIndex
-    self.session.setSelectedTarget(self.currentTargets.GetID(), modelIndex.row())
+    self.session.setSelectedTarget(self.currentTargets.GetID(), self.getCurrentTargetInfo())
     if not self.currentTargets:
       self.currentTargets = self.session.data.initialTargets
     self.jumpSliceNodesToNthTarget(modelIndex.row())


### PR DESCRIPTION
fixes #297 


@Kmacneil0102 the following code should be added to your TargetDisplacementPlugin

```
self.session.addEventObserver(self.session.TargetSelectionEvent, self.onTargetSelectionChanged)

@vtk.calldata_type(vtk.VTK_STRING)
def onTargetSelectionChanged(self, caller, event, callData):
  targetListId, index = ast.literal_eval(callData)
  if not targetListId or index == -1:
    # hide displacement widget
  else:
    # show displacement widget and set compute displacement
    targetList = slicer.mrmlScene.GetNodeByID(targetListId)
    print "%s, %s " % (targetListId, index)
```