### PR TITLE
ENH: added DICOMConnectionTestButton (issue #263):

### DIFF
--- a/SliceTracker/SliceTracker.py
+++ b/SliceTracker/SliceTracker.py
@@ -114,10 +114,13 @@ class SliceTrackerWidget(ModuleWidgetMixin, SliceTrackerConstants, ScriptedLoada
     self.crosshairButton = CrosshairButton()
     self.wlEffectsToolButton = WindowLevelEffectsButton()
     self.settingsButton = ModuleSettingsButton(self.moduleName)
-    self.showAnnotationsButton = self.createButton("", icon=Icons.text_info, iconSize=iconSize, checkable=True, toolTip="Display annotations", checked=True)
+    self.dicomConnectionTestButton = DICOMConnectionTestButton(toolTip="Test DICOM connection")
+    self.showAnnotationsButton = self.createButton("", icon=Icons.text_info, iconSize=iconSize, checkable=True,
+                                                   toolTip="Display annotations", checked=True)
 
     viewSettingButtons = [self.redOnlyLayoutButton, self.sideBySideLayoutButton, self.fourUpLayoutButton,
-                          self.crosshairButton,   self.wlEffectsToolButton, self.settingsButton]
+                          self.crosshairButton, self.wlEffectsToolButton, self.settingsButton,
+                          self.dicomConnectionTestButton]
 
     for step in self.session.steps:
       viewSettingButtons += step.viewSettingButtons


### PR DESCRIPTION
depends on QIICR/SlicerDevelopmentToolbox/pull/14

fixes #263


Third button from the right:
![image](https://user-images.githubusercontent.com/10195822/28484503-cffcdc8c-6e40-11e7-8a3f-dcb6c34a5727.png)
