### PR TITLE
ENH: Implement displacement chart as a plugin

### DIFF
--- a/SliceTracker/SliceTrackerUtils/steps/evaluation.py
+++ b/SliceTracker/SliceTrackerUtils/steps/evaluation.py
@@ -5,6 +5,7 @@ import slicer
 from base import SliceTrackerLogicBase, SliceTrackerStep
 from plugins.results import SliceTrackerRegistrationResultsPlugin
 from plugins.targets import SliceTrackerTargetTablePlugin
+from plugins.charts import SliceTrackerDisplacementChartPlugin
 
 from SlicerDevelopmentToolboxUtils.icons import Icons
 
@@ -43,11 +44,21 @@ class SliceTrackerEvaluationStep(SliceTrackerStep):
     self.targetTablePlugin = SliceTrackerTargetTablePlugin(movingEnabled=True)
     self.addPlugin(self.targetTablePlugin)
 
+    self.displacementChartPlugin = SliceTrackerDisplacementChartPlugin()
+    self.addPlugin(self.displacementChartPlugin)
+
+    self.displacementChartPlugin.addEventObserver(self.displacementChartPlugin.ShowEvent,
+                                                  lambda caller, event: self.displacementChartPlugin.show())
+    self.displacementChartPlugin.addEventObserver(self.displacementChartPlugin.HideEvent,
+                                                  lambda caller, event: self.displacementChartPlugin.hide())
+
+
     self.registrationEvaluationGroupBoxLayout.addWidget(self.regResultsPlugin, 3, 0)
     self.registrationEvaluationGroupBoxLayout.addWidget(self.targetTablePlugin, 4, 0)
     self.registrationEvaluationGroupBoxLayout.addWidget(self.registrationEvaluationButtonsGroupBox, 5, 0)
     self.registrationEvaluationGroupBoxLayout.setRowStretch(6, 1)
     self.layout().addWidget(self.registrationEvaluationGroupBox)
+    self.layout().addWidget(self.displacementChartPlugin)
 
   def setupRegistrationValidationButtons(self):
     iconSize = qt.QSize(36, 36)

--- a/SliceTracker/SliceTrackerUtils/steps/overview.py
+++ b/SliceTracker/SliceTrackerUtils/steps/overview.py
@@ -84,6 +84,7 @@ class SliceTrackerOverviewStep(SliceTrackerStep):
                                                   lambda caller, event: self.displacementChartPlugin.show())
     self.displacementChartPlugin.addEventObserver(self.displacementChartPlugin.HideEvent,
                                                   lambda caller, event: self.displacementChartPlugin.hide())
+    self.displacementChartPlugin.hide()
 
     self.layout().addWidget(self.caseManagerPlugin, 0, 0)
     self.layout().addWidget(self.trainingPlugin, 1, 0)

--- a/SliceTracker/SliceTrackerUtils/steps/overview.py
+++ b/SliceTracker/SliceTrackerUtils/steps/overview.py
@@ -80,6 +80,11 @@ class SliceTrackerOverviewStep(SliceTrackerStep):
     self.displacementChartPlugin = SliceTrackerDisplacementChartPlugin()
     self.addPlugin(self.displacementChartPlugin)
 
+    self.displacementChartPlugin.addEventObserver(self.displacementChartPlugin.ShowEvent,
+                                                  lambda caller, event: self.displacementChartPlugin.show())
+    self.displacementChartPlugin.addEventObserver(self.displacementChartPlugin.HideEvent,
+                                                  lambda caller, event: self.displacementChartPlugin.hide())
+
     self.layout().addWidget(self.caseManagerPlugin, 0, 0)
     self.layout().addWidget(self.trainingPlugin, 1, 0)
     self.layout().addWidget(self.targetTablePlugin, 2, 0)
@@ -200,11 +205,6 @@ class SliceTrackerOverviewStep(SliceTrackerStep):
 
   def onRegistrationStatusChanged(self, caller, event):
     self.active = True
-
-  def onCurrentResultChanged(self, caller, event):
-    if not self.active:
-      return
-    self.displacementChartPlugin.updateTargetDisplacementChart()
 
   def onLoadingMetadataSuccessful(self, caller, event):
     self.active = True

--- a/SliceTracker/SliceTrackerUtils/steps/overview.py
+++ b/SliceTracker/SliceTrackerUtils/steps/overview.py
@@ -9,6 +9,7 @@ from plugins.case import SliceTrackerCaseManagerPlugin
 from plugins.results import SliceTrackerRegistrationResultsPlugin
 from plugins.targets import SliceTrackerTargetTablePlugin
 from plugins.training import SliceTrackerTrainingPlugin
+from plugins.charts import SliceTrackerDisplacementChartPlugin
 from ..constants import SliceTrackerConstants as constants
 from ..sessionData import RegistrationResult
 from ..helpers import IncomingDataMessageBox, SeriesTypeToolButton, SeriesTypeManager
@@ -76,12 +77,16 @@ class SliceTrackerOverviewStep(SliceTrackerStep):
     self.targetTablePlugin = SliceTrackerTargetTablePlugin()
     self.addPlugin(self.targetTablePlugin)
 
+    self.displacementChartPlugin = SliceTrackerDisplacementChartPlugin()
+    self.addPlugin(self.displacementChartPlugin)
+
     self.layout().addWidget(self.caseManagerPlugin, 0, 0)
     self.layout().addWidget(self.trainingPlugin, 1, 0)
     self.layout().addWidget(self.targetTablePlugin, 2, 0)
     self.layout().addWidget(self.createHLayout([self.intraopSeriesSelector, self.changeSeriesTypeButton,
                                                 self.trackTargetsButton, self.skipIntraopSeriesButton]), 3, 0)
     self.layout().addWidget(self.regResultsCollapsibleButton, 4, 0)
+    self.layout().addWidget(self.displacementChartPlugin, 5, 0)
     # self.layout().setRowStretch(8, 1)
 
   def setupRegistrationResultsPlugin(self):
@@ -195,6 +200,11 @@ class SliceTrackerOverviewStep(SliceTrackerStep):
 
   def onRegistrationStatusChanged(self, caller, event):
     self.active = True
+
+  def onCurrentResultChanged(self, caller, event):
+    if not self.active:
+      return
+    self.displacementChartPlugin.updateTargetDisplacementChart()
 
   def onLoadingMetadataSuccessful(self, caller, event):
     self.active = True

--- a/SliceTracker/SliceTrackerUtils/steps/plugins/charts.py
+++ b/SliceTracker/SliceTrackerUtils/steps/plugins/charts.py
@@ -1,0 +1,245 @@
+import vtk
+import qt
+import ctk
+import ast
+
+
+from ..base import SliceTrackerPlugin, SliceTrackerLogicBase
+from ...session import SliceTrackerSession
+
+class SliceTrackerDisplacementChartLogic(SliceTrackerLogicBase):
+
+  def __init__(self):
+    super(SliceTrackerDisplacementChartLogic, self).__init__()
+    self.session = SliceTrackerSession()
+
+  def calculateTargetDisplacement(self, prevTargets, currTargets, targetIndex):
+    prevPos = [0.0, 0.0, 0.0]
+    currPos = [0.0, 0.0, 0.0]
+    currTargets.GetNthFiducialPosition(targetIndex, currPos)
+    prevTargets.GetNthFiducialPosition(targetIndex, prevPos)
+    displacement = [currPos[0] - prevPos[0], currPos[1] - prevPos[1], currPos[2] - prevPos[2]]
+    return displacement
+
+class SliceTrackerDisplacementChartPlugin(SliceTrackerPlugin):
+
+  NAME = "DisplacementChart"
+  LogicClass = SliceTrackerDisplacementChartLogic
+
+  @property
+  def chartView(self):
+    return self._chartView
+
+  @property
+  def chart(self):
+    return self._chartView.chart()
+
+  @property
+  def xAxis(self):
+    return self.chart.GetAxis(1)
+
+  @property
+  def yAxis(self):
+    return self.chart.GetAxis(0)
+
+  @property
+  def showLegend(self):
+    return self._showLegend
+
+  @showLegend.setter
+  def showLegend(self, value):
+    assert type(value) is bool, "Only boolean values are allowed for this class member"
+    self._showLegend = value
+    self.chart.SetShowLegend(value)
+
+  def __init__(self):
+    super(SliceTrackerDisplacementChartPlugin, self).__init__()
+    self.session = SliceTrackerSession()
+
+  def setup(self):
+    super(SliceTrackerDisplacementChartPlugin, self).setup()
+    self._chartView = ctk.ctkVTKChartView()
+    self._chartView.minimumSize = qt.QSize(200, 200)
+    self._chartView.hide()
+    self.showChart = False
+    self._showLegend = False
+    self.xAxis.SetTitle('Series Number')
+    self.yAxis.SetTitle('Displacement')
+    self.chartTable = vtk.vtkTable()
+
+    self.arrX = vtk.vtkFloatArray()
+    self.arrX.SetName('X Axis')
+
+    self.arrXD = vtk.vtkFloatArray()
+    self.arrXD.SetName('L/R Displacement')
+
+    self.arrYD = vtk.vtkFloatArray()
+    self.arrYD.SetName('P/A Displacement')
+
+    self.arrZD = vtk.vtkFloatArray()
+    self.arrZD.SetName('I/S Displacement')
+
+    self.arrD = vtk.vtkFloatArray()
+    self.arrD.SetName('3-D Distance')
+
+    self.chartTable.AddColumn(self.arrX)
+    self.chartTable.AddColumn(self.arrXD)
+    self.chartTable.AddColumn(self.arrYD)
+    self.chartTable.AddColumn(self.arrZD)
+    self.chartTable.AddColumn(self.arrD)
+
+    self.chartPopupWindow = None
+    self.chartPopupSize = qt.QSize(600, 300)
+    self.chartPopupPosition = qt.QPoint(0, 0)
+
+    self.showLegendCheckBox = qt.QCheckBox('Show legend')
+    self.showLegendCheckBox.setChecked(0)
+    self.showLegendCheckBox.hide()
+
+    self.plotFrame = ctk.ctkCollapsibleButton()
+    self.plotFrame.text = "Plotting"
+    self.plotFrame.collapsed = 0
+    plotFrameLayout = qt.QGridLayout(self.plotFrame)
+    self.plottingFrameWidget = qt.QWidget()
+    self.plottingFrameLayout = qt.QGridLayout()
+    self.plottingFrameWidget.setLayout(self.plottingFrameLayout)
+    self.plottingFrameLayout.addWidget(self.showLegendCheckBox, 0, 0)
+    self.plottingFrameLayout.addWidget(self._chartView, 1, 0)
+
+    self.popupChartButton = qt.QPushButton("Undock chart")
+    self.popupChartButton.setCheckable(True)
+    self.plottingFrameLayout.addWidget(self.popupChartButton, 2, 0)
+    plotFrameLayout.addWidget(self.plottingFrameWidget)
+    self.layout().addWidget(self.plotFrame)
+
+  def setupConnections(self):
+    self.popupChartButton.connect('toggled(bool)', self.onDockChartViewToggled)
+    self.showLegendCheckBox.connect('stateChanged(int)', self.onShowLegendChanged)
+    self.session.addEventObserver(self.session.TargetSelectionEvent, self.onTargetSelectionChanged)
+
+  def addPlotPoints(self, triplets, seriesNumber):
+    numCurrentRows = self.chartTable.GetNumberOfRows()
+    self.chartView.removeAllPlots()
+    for i in range(0, len(triplets)):
+      if numCurrentRows == 0:
+        self.arrX.InsertNextValue(seriesNumber - 1)
+        self.arrXD.InsertNextValue(0)
+        self.arrYD.InsertNextValue(0)
+        self.arrZD.InsertNextValue(0)
+        self.arrD.InsertNextValue(0)
+        self._chartView.show()
+        if not self.showLegendCheckBox.isVisible():
+          self.showLegendCheckBox.show()
+      self.arrX.InsertNextValue(seriesNumber)
+      self.arrXD.InsertNextValue(triplets[i][0])
+      self.arrYD.InsertNextValue(triplets[i][1])
+      self.arrZD.InsertNextValue(triplets[i][2])
+      distance = (triplets[i][0] ** 2 + triplets[i][1] ** 2 + triplets[i][2] ** 2) ** 0.5
+      self.arrD.InsertNextValue(distance)
+
+    xvals = vtk.vtkDoubleArray()
+    xlabels = vtk.vtkStringArray()
+    maxXIndex = self.arrX.GetNumberOfValues()
+    for j in range(0, maxXIndex):
+      xvals.InsertNextValue(self.arrX.GetValue(j))
+      xlabels.InsertNextValue(str(int(self.arrX.GetValue(j))))
+    self.xAxis.SetCustomTickPositions(xvals, xlabels)
+    self.xAxis.SetBehavior(vtk.vtkAxis.FIXED)
+    self.xAxis.SetRange(self.arrX.GetValue(0), self.arrX.GetValue(maxXIndex - 1) + 0.1)
+
+    plot = self.chart.AddPlot(vtk.vtkChart.LINE)
+    plot.SetInputData(self.chartTable, 0, 1)
+    plot.SetColor(255, 0, 0, 255)
+    vtk.vtkPlotLine.SafeDownCast(plot).SetMarkerStyle(4)
+    vtk.vtkPlotLine.SafeDownCast(plot).SetMarkerSize(3 * plot.GetPen().GetWidth())
+
+    plot2 = self.chart.AddPlot(vtk.vtkChart.LINE)
+    plot2.SetInputData(self.chartTable, 0, 2)
+    plot2.SetColor(0, 255, 0, 255)
+    vtk.vtkPlotLine.SafeDownCast(plot2).SetMarkerStyle(4)
+    vtk.vtkPlotLine.SafeDownCast(plot2).SetMarkerSize(3 * plot2.GetPen().GetWidth())
+
+    plot3 = self.chart.AddPlot(vtk.vtkChart.LINE)
+    plot3.SetInputData(self.chartTable, 0, 3)
+    plot3.SetColor(0, 0, 255, 255)
+    vtk.vtkPlotLine.SafeDownCast(plot3).SetMarkerStyle(4)
+    vtk.vtkPlotLine.SafeDownCast(plot3).SetMarkerSize(3 * plot3.GetPen().GetWidth())
+
+    plot4 = self.chart.AddPlot(vtk.vtkChart.LINE)
+    plot4.SetInputData(self.chartTable, 0, 4)
+    plot4.SetColor(0, 0, 0, 255)
+    vtk.vtkPlotLine.SafeDownCast(plot4).SetMarkerStyle(4)
+    vtk.vtkPlotLine.SafeDownCast(plot4).SetMarkerSize(3 * plot4.GetPen().GetWidth())
+
+  def resetChart(self):
+    self.arrX.Initialize()
+    self.arrXD.Initialize()
+    self.arrYD.Initialize()
+    self.arrZD.Initialize()
+    self.arrD.Initialize()
+    if self.showLegendCheckBox.isChecked() and not self._chartView.isVisible():
+      self.showLegendCheckBox.setChecked(False)
+
+  def updateTargetDisplacementChart(self):
+    if self.isTargetDisplacementChartDisplayable(self.session.currentSeries):
+      self.resetChart()
+      results = sorted(self.session.data.getResultsAsList(), key=lambda s: s.seriesNumber)
+      prevIndex = 0
+      for currIndex, currResult in enumerate(results[1:], 1):
+        if results[prevIndex].approved and currResult.approved:
+          prevTargets = results[prevIndex].targets.approved
+          currTargets = currResult.targets.approved
+          displacement = self.logic.calculateTargetDisplacement(prevTargets, currTargets, self.targetIndex)
+          self.addPlotPoints([displacement], currResult.seriesNumber)
+          prevIndex = currIndex
+        elif currResult.approved:
+          prevIndex = currIndex
+        else:
+          prevIndex += 1
+
+  def isTargetDisplacementChartDisplayable(self, selectedSeries):
+    return not (self.session.seriesTypeManager.isCoverProstate(selectedSeries) or not self.showChart
+                or not self.session.data.registrationResultWasApproved(selectedSeries))
+
+  def onShowLegendChanged(self, checked):
+    self.chart.SetShowLegend(True if checked == 2 else False)
+    self.chartView.scene().SetDirty(True)
+
+  @vtk.calldata_type(vtk.VTK_STRING)
+  def onTargetSelectionChanged(self, caller, event, callData):
+    info = ast.literal_eval(callData)
+    if not info['nodeId'] or info['index'] == -1:
+      self.showChart = False
+      self.resetChart()
+    else:
+      self.targetIndex = info['index']
+      self.showChart = True
+      self.updateTargetDisplacementChart()
+      print "%s" % info
+
+  def onDockChartViewToggled(self, checked):
+    if checked:
+      self.chartPopupWindow = qt.QDialog()
+      self.chartPopupWindow.setWindowFlags(qt.Qt.WindowStaysOnTopHint)
+      layout = qt.QGridLayout()
+      self.chartPopupWindow.setLayout(layout)
+      layout.addWidget(self.showLegendCheckBox, 0, 0)
+      layout.addWidget(self._chartView, 1, 0)
+      self.chartPopupWindow.finished.connect(self.dockChartView)
+      self.chartPopupWindow.resize(self.chartPopupSize)
+      self.chartPopupWindow.move(self.chartPopupPosition)
+      self.chartPopupWindow.show()
+      self.popupChartButton.hide()
+    else:
+      self.chartPopupWindow.close()
+
+  def dockChartView(self):
+    self.chartPopupSize = self.chartPopupWindow.size
+    self.chartPopupPosition = self.chartPopupWindow.pos
+    self.plottingFrameLayout.addWidget(self.showLegendCheckBox, 0, 0)
+    self.plottingFrameLayout.addWidget(self._chartView, 1, 0)
+    self.plottingFrameLayout.addWidget(self.popupChartButton, 2, 0)
+    self.popupChartButton.blockSignals(True)
+    self.popupChartButton.checked = False
+    self.popupChartButton.show()
+    self.popupChartButton.blockSignals(False)


### PR DESCRIPTION
Fixes #84.

- Displays the I/S, P/A, L/R and 3-D displacement as individual plots for the currently selected target, for all series with approved registrations

@fedorov Currently chart only displayed during the Overview step, do you think it might be beneficial to also display it in the Evaluation step? 