### PR TITLE
ENH: Update SliceTracker to most recent DeepInfer version (issue #286)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set(EXTENSION_DESCRIPTION "This extension provides modules to support in-bore MR
 set(EXTENSION_ICONURL "https://www.slicer.org/w/images/b/b1/SliceTracker_Logo_1.1_128x128.png")
 set(EXTENSION_SCREENSHOTURLS "http://wiki.slicer.org/slicerWiki/images/7/78/Slicetracker.gif")
 set(EXTENSION_STATUS "beta")
-set(EXTENSION_DEPENDS "SlicerProstate SlicerDevelopmentToolbox mpReview SegmentEditorExtraEffects")
+set(EXTENSION_DEPENDS "SlicerDevelopmentToolbox mpReview SegmentEditorExtraEffects DeepInfer")
 
 #-----------------------------------------------------------------------------
 find_package(Slicer REQUIRED)

--- a/SliceTracker/SliceTracker.py
+++ b/SliceTracker/SliceTracker.py
@@ -28,7 +28,7 @@ class SliceTracker(ScriptedLoadableModule):
     ScriptedLoadableModule.__init__(self, parent)
     self.parent.title = "SliceTracker"
     self.parent.categories = ["Radiology"]
-    self.parent.dependencies = ["SlicerProstate", "SlicerDevelopmentToolbox", "mpReview", "mpReviewPreprocessor"]
+    self.parent.dependencies = ["SlicerDevelopmentToolbox", "mpReview", "mpReviewPreprocessor"]
     self.parent.contributors = ["Christian Herz (SPL)", "Peter Behringer (SPL)", "Andriy Fedorov (SPL)"]
     self.parent.helpText = """ SliceTracker facilitates support of MRI-guided targeted prostate biopsy.
       See <a href=\"https://www.gitbook.com/book/slicerprostate/slicetracker/details\">the documentation</a> for

--- a/SliceTracker/SliceTracker.py
+++ b/SliceTracker/SliceTracker.py
@@ -28,7 +28,8 @@ class SliceTracker(ScriptedLoadableModule):
     ScriptedLoadableModule.__init__(self, parent)
     self.parent.title = "SliceTracker"
     self.parent.categories = ["Radiology"]
-    self.parent.dependencies = ["SlicerDevelopmentToolbox", "mpReview", "mpReviewPreprocessor"]
+    self.parent.dependencies = ["SlicerDevelopmentToolbox", "mpReview", "mpReviewPreprocessor",
+                                "SegmentEditorExtraEffects","DeepInfer"]
     self.parent.contributors = ["Christian Herz (SPL)", "Peter Behringer (SPL)", "Andriy Fedorov (SPL)"]
     self.parent.helpText = """ SliceTracker facilitates support of MRI-guided targeted prostate biopsy.
       See <a href=\"https://www.gitbook.com/book/slicerprostate/slicetracker/details\">the documentation</a> for

--- a/SliceTracker/SliceTrackerUtils/steps/plugins/segmentation/base.py
+++ b/SliceTracker/SliceTrackerUtils/steps/plugins/segmentation/base.py
@@ -6,6 +6,7 @@ class SliceTrackerSegmentationPluginBase(SliceTrackerPlugin):
 
   SegmentationStartedEvent = vtk.vtkCommand.UserEvent + 435
   SegmentationFinishedEvent = vtk.vtkCommand.UserEvent + 436
+  SegmentationFailedEvent = vtk.vtkCommand.UserEvent + 437
 
   def __init__(self):
     super(SliceTrackerSegmentationPluginBase, self).__init__()
@@ -19,3 +20,6 @@ class SliceTrackerSegmentationPluginBase(SliceTrackerPlugin):
   @vtk.calldata_type(vtk.VTK_OBJECT)
   def _onSegmentationFinished(self, caller, event, labelNode):
     self.invokeEvent(self.SegmentationFinishedEvent, labelNode)
+
+  def _onSegmentationFailed(self, caller, event):
+    self.invokeEvent(self.SegmentationFailedEvent)

--- a/SliceTracker/SliceTrackerUtils/steps/plugins/segmentation/manual.py
+++ b/SliceTracker/SliceTrackerUtils/steps/plugins/segmentation/manual.py
@@ -99,7 +99,7 @@ class SliceTrackerManualSegmentationPlugin(SliceTrackerSegmentationPluginBase):
   def _preCheckExistingSegmentation(self):
     if not slicer.util.confirmYesNoDisplay("The automatic segmentation will be overwritten. Do you want to proceed?",
                                            windowTitle="SliceTracker"):
-      self.surfaceCutToLabelWidget.stopQuickSegmentationMode(cancelled=True)
+      self.surfaceCutToLabelWidget.logic.stopQuickSegmentationMode(cancelled=True)
       return False
     return True
 

--- a/SliceTracker/SliceTrackerUtils/steps/segmentation.py
+++ b/SliceTracker/SliceTrackerUtils/steps/segmentation.py
@@ -61,6 +61,8 @@ class SliceTrackerSegmentationStep(SliceTrackerStep):
     self.automaticSegmentationPlugin = SliceTrackerAutomaticSegmentationPlugin()
     self.automaticSegmentationPlugin.addEventObserver(self.automaticSegmentationPlugin.SegmentationStartedEvent,
                                                       self._onAutomaticSegmentationStarted)
+    self.automaticSegmentationPlugin.addEventObserver(self.automaticSegmentationPlugin.SegmentationFailedEvent,
+                                                   self._onSegmentationFailed)
     self.automaticSegmentationPlugin.addEventObserver(self.automaticSegmentationPlugin.SegmentationFinishedEvent,
                                                       self._onAutomaticSegmentationFinished)
     self.addPlugin(self.automaticSegmentationPlugin)
@@ -225,6 +227,14 @@ class SliceTrackerSegmentationStep(SliceTrackerStep):
     if self._inputsAreSet():
       self._displaySegmentationComparison()
     self.finishStepButton.setEnabled(1 if self._inputsAreSet() else 0) # TODO: need to revise that
+
+  def _onSegmentationFailed(self, caller, event):
+    import logging
+    logging.debug("Segmentation failed")
+    self.setAvailableLayouts([constants.LAYOUT_FOUR_UP])
+    self.layoutManager.setLayout(constants.LAYOUT_FOUR_UP)
+    self.backButton.enabled = True
+    self.finishStepButton.setEnabled(False)
 
   @vtk.calldata_type(vtk.VTK_STRING)
   def onNewImageSeriesReceived(self, caller, event, callData):


### PR DESCRIPTION
fixes #286 
fixes #305

partially fixes #279

* using DeepInfer directly from SliceTracker without using any temp
  created volumes, directories
* TODO:
  - [ ] if deamon is not running and using DeepInfer from cmdline,
    python fails because it searches for the DeepInferWidget
    --> that needs to be fixed on side of DeepInfer
  - [ ] also there is no progress feedback (callback) when executing DeepInfer

