### PR TITLE
WIP: integration of automatic preop prostate segmentation (issue #311)

### DIFF
--- a/SliceTracker/SliceTrackerUtils/algorithms/automaticProstateSegmentation.py
+++ b/SliceTracker/SliceTrackerUtils/algorithms/automaticProstateSegmentation.py
@@ -1,0 +1,80 @@
+import os
+import logging
+import json
+import vtk
+from collections import OrderedDict
+
+import slicer
+import DeepInfer
+
+from SlicerDevelopmentToolboxUtils.mixins import  ModuleLogicMixin
+
+
+class AutomaticSegmentationLogic(ModuleLogicMixin):
+
+  DeepLearningStartedEvent =  vtk.vtkCommand.UserEvent + 438
+  DeepLearningFinishedEvent = vtk.vtkCommand.UserEvent + 439
+  DeepLearningFailedEvent = vtk.vtkCommand.UserEvent + 441
+  # DeepLearningStatusChangedEvent = vtk.vtkCommand.UserEvent + 440
+
+  def __init__(self):
+    self.inputVolume = None
+    self.colorNode = None
+
+  def cleanup(self):
+    self.inputVolume = None
+
+  def run(self, inputVolume, colorNode=None):
+
+    self.colorNode = colorNode
+    if not inputVolume:
+      raise ValueError("No input volume found for initializing prostate segmentation deep learning.")
+
+    self.inputVolume = inputVolume
+    self.invokeEvent(self.DeepLearningStartedEvent)
+    outputLabel = self._runDocker()
+
+    if outputLabel:
+      self.dilateMask(outputLabel)
+      self.invokeEvent(self.DeepLearningFinishedEvent, outputLabel)
+    else:
+      self.invokeEvent(self.DeepLearningFailedEvent)
+
+  def _runDocker(self):
+    logic = DeepInfer.DeepInferLogic()
+    parameters = DeepInfer.ModelParameters()
+    with open(os.path.join(DeepInfer.JSON_LOCAL_DIR, "ProstateSegmenter.json"), "r") as fp:
+      j = json.load(fp, object_pairs_hook=OrderedDict)
+
+    iodict = parameters.create_iodict(j)
+    dockerName, modelName, dataPath = parameters.create_model_info(j)
+    logging.debug(iodict)
+
+    inputs = {
+      'InputVolume' : self.inputVolume
+    }
+
+    outputLabel = slicer.vtkMRMLLabelMapVolumeNode()
+    outputLabel.SetName(self.inputVolume.GetName()+"-label")
+    slicer.mrmlScene.AddNode(outputLabel)
+    outputs = {'OutputLabel': outputLabel}
+
+    params = dict()
+    params['Domain'] = 'Automatic'
+    params['OutputSmoothing'] = 1
+    params['ProcessingType'] = 'Fast'
+    params['InferenceType'] = 'Single'
+    params['verbose'] = 1
+
+    logic.executeDocker(dockerName, modelName, dataPath, iodict, inputs, params)
+
+    if logic.abort:
+      return None
+
+    logic.updateOutput(iodict, outputs)
+
+    if self.colorNode:
+      displayNode = outputLabel.GetDisplayNode()
+      displayNode.SetAndObserveColorNodeID(self.colorNode.GetID())
+
+    return outputLabel

--- a/SliceTracker/SliceTrackerUtils/session.py
+++ b/SliceTracker/SliceTrackerUtils/session.py
@@ -728,18 +728,6 @@ class SliceTrackerSession(StepBasedSession):
         targetList.AddFiducialFromArray(self.getTargetPosition(self.temporaryIntraopTargets, i),
                                         self.temporaryIntraopTargets.GetNthFiducialLabel(i))
 
-  def runBRAINSResample(self, inputVolume, referenceVolume, outputVolume, warpTransform=None):
-
-    params = {'inputVolume': inputVolume, 'referenceVolume': referenceVolume, 'outputVolume': outputVolume,
-              'interpolationMode': 'NearestNeighbor', 'pixelType':'short'}
-    if warpTransform:
-      params['warpTransform'] = warpTransform
-
-    logging.debug('About to run BRAINSResample CLI with those params: %s' % params)
-    slicer.cli.run(slicer.modules.brainsresample, None, params, wait_for_completion=True)
-    logging.debug('resample labelmap through')
-    slicer.mrmlScene.AddNode(outputVolume)
-
   @logmethod(logging.INFO)
   def onRegistrationResultStatusChanged(self, caller, event):
     self.skipAllUnregisteredPreviousSeries(self.currentResult.name)

--- a/SliceTracker/SliceTrackerUtils/session.py
+++ b/SliceTracker/SliceTrackerUtils/session.py
@@ -1,11 +1,14 @@
 import os, logging
 import vtk, ctk, ast
+import xml
+import getpass
+import datetime
 
 import slicer
 from sessionData import SessionData, RegistrationResult, RegistrationTypeData
 from constants import SliceTrackerConstants
 from helpers import SeriesTypeManager
-
+from algorithms.automaticProstateSegmentation import AutomaticSegmentationLogic
 
 from SlicerDevelopmentToolboxUtils.constants import DICOMTAGS, FileExtension, STYLE
 from SlicerDevelopmentToolboxUtils.events import SlicerDevelopmentToolboxEvents
@@ -885,64 +888,114 @@ class PreopDataHandler(PreprocessedDataHandlerBase):
       self.invokeEvent(self.PreprocessedDataErrorEvent)
 
   def loadMpReviewProcessedData(self):
-    from mpReview import mpReviewLogic
     studyDir = self.getFirstMpReviewPreprocessedStudy(self.outputDirectory)
     resourcesDir = os.path.join(studyDir, 'RESOURCES')
-    logging.debug(resourcesDir)
-    if not os.path.exists(resourcesDir):
-      logging.info("The selected directory does not fit the mpReview directory structure. Make sure that you select "
-                   "the study root directory which includes directories RESOURCES")
+    if not self.isMpReviewStudyDirectoryValid(resourcesDir):
+      self.invokeEvent(self.PreprocessedDataErrorEvent)
+      return
+
+    self.findPreopImageAndSegmentationPaths(resourcesDir)
+
+    message = None
+    if not self.preopSegmentationPath:
+      slicer.util.errorDisplay("No eligible series found for preop AX T2 segmentation. MpReview might not have "
+                               "processed the right series or series names are different from BWH internally used ones")
       self.invokeEvent(self.PreprocessedDataErrorEvent)
       return
 
     self.data.initialTargetsPath = os.path.join(studyDir, 'Targets')
-    seriesMap, metaFile = mpReviewLogic.loadMpReviewProcessedData(resourcesDir)
-    self.loadPreopImageAndLabel(seriesMap)
 
-    message = None
-    if self.preopSegmentationPath is None:
-      message = "No segmentations found.\nMake sure that you used mpReview for segmenting the prostate first and using " \
-                "its output as the preop data input here."
-      logging.info(message)
+    loadedPreopVolume = self.loadPreopVolume()
+    loadedPreopTargets = self.loadPreopTargets()
+    loadedPreopT2Label = self.loadT2Label() if os.path.exists(self.preopSegmentationPath) else False
 
-    if message or not (self.loadT2Label() and self.loadPreopVolume() and self.loadPreopTargets()):
-      message = "Loading preop data failed.\nMake sure that the correct mpReview directory structure is used." \
-                "\n\nSliceTracker expects a T2 volume, WholeGland segmentation and target(s). Do you want to " \
-                "open/revisit pre-processing for the current case?"
-      if slicer.util.confirmYesNoDisplay(message, windowTitle="SliceTracker"):
-        # TODO: start intraop without listening to signals
-        self.runModule()
+    if message or not (loadedPreopT2Label and loadedPreopVolume and loadedPreopTargets):
+      if loadedPreopTargets and loadedPreopVolume and \
+          self.getSetting("Use_Deep_Learning", moduleName=self.MODULE_NAME).lower() == "true":
+        if slicer.util.confirmYesNoDisplay("No WholeGland segmentation found in preop data. Automatic segmentation is "
+                                           "available. Would you like to proceed with the automatic segmentation?",
+                                           windowTitle="SliceTracker"):
+          self.runAutomaticSegmentation()
+        else:
+          self.onPreopLoadingFailed()
       else:
-        self.invokeEvent(self.PreprocessedDataErrorEvent)
+        self.onPreopLoadingFailed()
     else:
       self.invokeEvent(self.PreprocessingFinishedEvent)
 
-  def loadPreopImageAndLabel(self, seriesMap):
+  def runAutomaticSegmentation(self):
+    logic = AutomaticSegmentationLogic()
+    logic.addEventObserver(logic.DeepLearningFinishedEvent, self.onSegmentationFinished)
+    logic.addEventObserver(logic.DeepLearningFailedEvent, self.onPreopLoadingFailed)
+    customStatusProgressBar = CustomStatusProgressbar()
+    customStatusProgressBar.text = "Running DeepInfer for automatic prostate segmentation"
+
+    print self.data.initialVolume.GetName()
+    from mpReview import mpReviewLogic
+    mpReviewColorNode, _ = mpReviewLogic.loadColorTable(self.getSetting("Color_File_Name", moduleName=self.MODULE_NAME))
+
+    logic.run(self.data.initialVolume)
+
+  @vtk.calldata_type(vtk.VTK_OBJECT)
+  def onSegmentationFinished(self, caller, event, labelNode):
+    if not self.preopSegmentationPath:
+      self.createDirectory(self.preopSegmentationPath)
+    segmentedColorName = self.getSetting("Segmentation_Color_Name", moduleName=self.MODULE_NAME)
+    timestamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
+    filename = getpass.getuser() + '-' + segmentedColorName + '-' + timestamp
+    self.saveNodeData(labelNode, self.preopSegmentationPath, extension=FileExtension.NRRD, name=filename)
+    self.loadPreProcessedData()
+    customStatusProgressBar = CustomStatusProgressbar()
+    customStatusProgressBar.text = "Done automatic prostate segmentation"
+
+  def isMpReviewStudyDirectoryValid(self, resourcesDir):
+    logging.debug(resourcesDir)
+    if not os.path.exists(resourcesDir):
+      logging.info("The selected directory does not fit the mpReview directory structure. Make sure that you select "
+                   "the study root directory which includes directories RESOURCES")
+      return False
+    return True
+
+  def onPreopLoadingFailed(self, caller=None, event=None):
+    message = "Loading preop data failed.\nMake sure that the correct mpReview directory structure is used." \
+              "\n\nSliceTracker expects a T2 volume, WholeGland segmentation and target(s). Do you want to " \
+              "open/revisit pre-processing for the current case?"
+    if slicer.util.confirmYesNoDisplay(message, windowTitle="SliceTracker"):
+      # TODO: start intraop without listening to signals
+      self.runModule()
+    else:
+      self.invokeEvent(self.PreprocessedDataErrorEvent)
+
+  def findPreopImageAndSegmentationPaths(self, resourcesDir):
+    from mpReview import mpReviewLogic
+    seriesMap, metaFile = mpReviewLogic.loadMpReviewProcessedData(resourcesDir)
+
     self.preopImagePath = None
     self.preopSegmentationPath = None
-    segmentedColorName = self.getSetting("Segmentation_Color_Name", moduleName=self.MODULE_NAME) # TODO: correct?
+    # segmentedColorName = self.getSetting("Segmentation_Color_Name", moduleName=self.MODULE_NAME) # TODO: correct?
 
     for series in seriesMap:
       seriesName = str(seriesMap[series]['LongName'])
       logging.debug('series Number ' + series + ' ' + seriesName)
 
       imagePath = os.path.join(seriesMap[series]['NRRDLocation'])
-      segmentationPath = os.path.dirname(os.path.dirname(imagePath))
-      segmentationPath = os.path.join(segmentationPath, 'Segmentations')
 
-      if not os.path.exists(segmentationPath):
-        continue
-      else:
-        if any(segmentedColorName in name for name in os.listdir(segmentationPath)):
-          logging.debug(' FOUND THE SERIES OF INTEREST, ITS ' + seriesName)
-          logging.debug(' LOCATION OF VOLUME : ' + str(seriesMap[series]['NRRDLocation']))
-          logging.debug(' LOCATION OF IMAGE path : ' + str(imagePath))
+      xmlFile = imagePath.replace(".nrrd", ".xml")
+      dom = xml.dom.minidom.parse(xmlFile)
+      seriesDescription = self.findElement(dom, "SeriesDescription")
 
-          logging.debug(' LOCATION OF SEGMENTATION path : ' + segmentationPath)
+      segmentationsPath = os.path.join(os.path.dirname(os.path.dirname(imagePath)), 'Segmentations')
 
-          self.preopImagePath = seriesMap[series]['NRRDLocation']
-          self.preopSegmentationPath = segmentationPath
-          break
+      # TODO: is the following line not flexible enough for external? What if several images match?
+      if seriesDescription.find("AX") != -1 and seriesDescription.find("T2") != -1:
+        logging.debug(' FOUND THE SERIES OF INTEREST, ITS ' + seriesName)
+        logging.debug(' LOCATION OF VOLUME : ' + str(seriesMap[series]['NRRDLocation']))
+        logging.debug(' LOCATION OF IMAGE path : ' + str(imagePath))
+        logging.debug(' EXPECTED LOCATION OF SEGMENTATION path : ' + segmentationsPath)
+
+        self.preopImagePath = seriesMap[series]['NRRDLocation']
+        self.preopSegmentationPath = segmentationsPath
+        break
 
   def loadT2Label(self):
     if self.data.initialLabel:

--- a/SliceTracker/SliceTrackerUtils/session.py
+++ b/SliceTracker/SliceTrackerUtils/session.py
@@ -405,8 +405,7 @@ class SliceTrackerSession(StepBasedSession):
   def onDICOMReceiverStatusChanged(self, caller, event, callData):
     customStatusProgressBar = CustomStatusProgressbar()
     customStatusProgressBar.text = callData
-    if "Waiting" in callData:
-      customStatusProgressBar.busy = True
+    customStatusProgressBar.busy = "Waiting" in callData
 
   def importDICOMSeries(self, newFileList):
     indexer = ctk.ctkDICOMIndexer()
@@ -922,7 +921,10 @@ class PreopDataHandler(PreprocessedDataHandlerBase):
     from mpReview import mpReviewLogic
     mpReviewColorNode, _ = mpReviewLogic.loadColorTable(self.getSetting("Color_File_Name", moduleName=self.MODULE_NAME))
 
-    logic.run(self.data.initialVolume)
+    domain = 'BWH_WITHOUT_ERC'
+    if slicer.util.confirmYesNoDisplay("Was an endorectal coil used during preop acqusition?"):
+      domain = 'BWH_WITH_ERC'
+    logic.run(self.data.initialVolume, domain, mpReviewColorNode)
 
   @vtk.calldata_type(vtk.VTK_OBJECT)
   def onSegmentationFinished(self, caller, event, labelNode):

--- a/SliceTracker/SliceTrackerUtils/steps/plugins/segmentation/automatic.py
+++ b/SliceTracker/SliceTrackerUtils/steps/plugins/segmentation/automatic.py
@@ -1,88 +1,12 @@
 import vtk
-import os
-import logging
-import slicer
-import DeepInfer
-from collections import OrderedDict
-import json
-
 
 from base import SliceTrackerSegmentationPluginBase
-from ...base import SliceTrackerLogicBase
-
-
-class SliceTrackerAutomaticSegmentationLogic(SliceTrackerLogicBase):
-
-  DeepLearningStartedEvent =  vtk.vtkCommand.UserEvent + 438
-  DeepLearningFinishedEvent = vtk.vtkCommand.UserEvent + 439
-  DeepLearningFailedEvent = vtk.vtkCommand.UserEvent + 441
-  # DeepLearningStatusChangedEvent = vtk.vtkCommand.UserEvent + 440
-
-  def __init__(self):
-    super(SliceTrackerAutomaticSegmentationLogic, self).__init__()
-    self.inputVolume = None
-
-  def cleanup(self):
-    super(SliceTrackerAutomaticSegmentationLogic, self).cleanup()
-    self.inputVolume = None
-
-  def run(self, inputVolume):
-    if not inputVolume:
-      raise ValueError("No input volume found for initializing prostate segmentation deep learning.")
-
-    self.inputVolume = inputVolume
-    self.invokeEvent(self.DeepLearningStartedEvent)
-    outputLabel = self._runDocker()
-
-    if outputLabel:
-      self.dilateMask(outputLabel)
-      self.invokeEvent(self.DeepLearningFinishedEvent, outputLabel)
-    else:
-      self.invokeEvent(self.DeepLearningFailedEvent)
-
-  def _runDocker(self):
-    logic = DeepInfer.DeepInferLogic()
-    parameters = DeepInfer.ModelParameters()
-    with open(os.path.join(DeepInfer.JSON_LOCAL_DIR, "ProstateSegmenter.json"), "r") as fp:
-      j = json.load(fp, object_pairs_hook=OrderedDict)
-
-    iodict = parameters.create_iodict(j)
-    dockerName, modelName, dataPath = parameters.create_model_info(j)
-    logging.debug(iodict)
-
-    inputs = {
-      'InputVolume' : self.inputVolume
-    }
-
-    outputLabel = slicer.vtkMRMLLabelMapVolumeNode()
-    outputLabel.SetName(self.inputVolume.GetName()+"-label")
-    slicer.mrmlScene.AddNode(outputLabel)
-    outputs = {'OutputLabel': outputLabel}
-
-    params = dict()
-    params['Domain'] = 'BWH_WITHOUT_ERC'
-    params['OutputSmoothing'] = 1
-    params['ProcessingType'] = 'Fast'
-    params['InferenceType'] = 'Single'
-    params['verbose'] = 1
-
-    logic.executeDocker(dockerName, modelName, dataPath, iodict, inputs, params)
-
-    if logic.abort:
-      return None
-
-    logic.updateOutput(iodict, outputs)
-
-    displayNode = outputLabel.GetDisplayNode()
-    displayNode.SetAndObserveColorNodeID(self.session.mpReviewColorNode.GetID())
-
-    return outputLabel
-
+from ....algorithms.automaticProstateSegmentation import AutomaticSegmentationLogic
 
 class SliceTrackerAutomaticSegmentationPlugin(SliceTrackerSegmentationPluginBase):
 
   NAME = "AutomaticSegmentation"
-  LogicClass = SliceTrackerAutomaticSegmentationLogic
+  LogicClass = AutomaticSegmentationLogic
 
   def __init__(self):
     super(SliceTrackerAutomaticSegmentationPlugin, self).__init__()
@@ -99,11 +23,11 @@ class SliceTrackerAutomaticSegmentationPlugin(SliceTrackerSegmentationPluginBase
     super(SliceTrackerAutomaticSegmentationPlugin, self).setup()
 
   def onActivation(self):
-    if self.getSetting("Use_Deep_Learning") == "true":
+    if self.getSetting("Use_Deep_Learning").lower() == "true":
       self.startSegmentation()
 
   def startSegmentation(self):
-    self.logic.run(self.session.fixedVolume)
+    self.logic.run(self.session.fixedVolume, colorNode=self.session.mpReviewColorNode)
 
   @vtk.calldata_type(vtk.VTK_OBJECT)
   def _onSegmentationFinished(self, caller, event, labelNode):

--- a/SliceTracker/SliceTrackerUtils/steps/plugins/segmentation/automatic.py
+++ b/SliceTracker/SliceTrackerUtils/steps/plugins/segmentation/automatic.py
@@ -27,7 +27,7 @@ class SliceTrackerAutomaticSegmentationPlugin(SliceTrackerSegmentationPluginBase
       self.startSegmentation()
 
   def startSegmentation(self):
-    self.logic.run(self.session.fixedVolume, colorNode=self.session.mpReviewColorNode)
+    self.logic.run(self.session.fixedVolume, domain='BWH_WITHOUT_ERC', colorNode=self.session.mpReviewColorNode)
 
   @vtk.calldata_type(vtk.VTK_OBJECT)
   def _onSegmentationFinished(self, caller, event, labelNode):

--- a/SliceTracker/SliceTrackerUtils/steps/segmentation.py
+++ b/SliceTracker/SliceTrackerUtils/steps/segmentation.py
@@ -115,7 +115,6 @@ class SliceTrackerSegmentationStep(SliceTrackerStep):
     if self.layoutManager.layout == constants.LAYOUT_SIDE_BY_SIDE:
       self._setupSideBySideSegmentationView()
     elif self.layoutManager.layout in [constants.LAYOUT_FOUR_UP, constants.LAYOUT_RED_SLICE_ONLY]:
-      self.redCompositeNode.SetLabelVolumeID(None)
       self._removeMissingPreopDataAnnotation()
       self.setBackgroundToVolumeID(self.session.currentSeriesVolume, clearLabels=False)
 

--- a/puml/SliceTrackerPlugins.puml
+++ b/puml/SliceTrackerPlugins.puml
@@ -111,10 +111,10 @@ package "SliceTracker Plugins" #DDDDDD {
     class SliceTrackerAutomaticSegmentationPlugin {
       + LogicClass
     }
-    class SliceTrackerAutomaticSegmentationLogic
+    class AutomaticSegmentationLogic
 
     SliceTrackerSegmentationPluginBase <|--SliceTrackerAutomaticSegmentationPlugin
-    SliceTrackerAutomaticSegmentationLogic <.. SliceTrackerAutomaticSegmentationPlugin::LogicClass: uses
+    AutomaticSegmentationLogic <.. SliceTrackerAutomaticSegmentationPlugin::LogicClass: uses
 
 
     class SliceTrackerManualSegmentationPlugin {


### PR DESCRIPTION
fixes #311 

* extracted logic for automatic segmentation into separate class which
  is non session dependent and can be used within PreopHandler
* user gets prompted if deep learning is enabled and everything but
  prostate segmentation was found

The following logic is executed:

1. iterate through seriesmap and read xml tag 'seriesDescription' with 'AX' and 'T2' which would be the right image volume knowing that the segmentation should be saved for the same image volume.

2. if no 'Segmentations' directory is available, but image volume and targets were successfully loaded AND deep learning is activated in SliceTracker settings, then notify user and ask if automatic segmentation should be executed.
    1. YES -> run DeepInfer
    2. NO -> ask user if case should be revisited in mpReview.
        a. YES -> run mpReview
        b. NO -> close case


depends on https://github.com/QIICR/SlicerDevelopmentToolbox/pull/20
