### PR TITLE
Fix testing bugs listed in 312

### DIFF
--- a/SliceTracker/SliceTrackerUtils/steps/evaluation.py
+++ b/SliceTracker/SliceTrackerUtils/steps/evaluation.py
@@ -95,6 +95,11 @@ class SliceTrackerEvaluationStep(SliceTrackerStep):
     results = self.session.data.getResultsBySeriesNumber(self.currentResult.seriesNumber)
     for result in [r for r in results if r is not self.currentResult]:
       result.reject()
+
+    if self.session.seriesTypeManager.isCoverProstate(self.session.currentResult.name) and \
+    self.session.data.getMostRecentApprovedCoverProstateRegistration() is not None:
+      self.session.data.getMostRecentApprovedCoverProstateRegistration().reject()
+
     self.currentResult.approve(registrationType=self.regResultsPlugin.registrationButtonGroup.checkedButton().name)
     # if self.ratingWindow.isRatingEnabled():
     #   self.ratingWindow.show(disableWidget=self.parent)

--- a/SliceTracker/SliceTrackerUtils/steps/overview.py
+++ b/SliceTracker/SliceTrackerUtils/steps/overview.py
@@ -80,7 +80,7 @@ class SliceTrackerOverviewStep(SliceTrackerStep):
     self.displacementChartPlugin = SliceTrackerDisplacementChartPlugin()
     self.addPlugin(self.displacementChartPlugin)
 
-    self.displacementChartPlugin.addEventObserver(self.displacementChartPlugin.ShowEvent, self.omShowDisplacementChart)
+    self.displacementChartPlugin.addEventObserver(self.displacementChartPlugin.ShowEvent, self.onShowDisplacementChart)
     self.displacementChartPlugin.addEventObserver(self.displacementChartPlugin.HideEvent, self.onHideDisplacementChart)
     self.displacementChartPlugin.collapsibleButton.hide()
 
@@ -93,7 +93,7 @@ class SliceTrackerOverviewStep(SliceTrackerStep):
     self.layout().addWidget(self.displacementChartPlugin.collapsibleButton, 5, 0)
     # self.layout().setRowStretch(8, 1)
 
-  def omShowDisplacementChart(self, caller, event):
+  def onShowDisplacementChart(self, caller, event):
     self.displacementChartPlugin.collapsibleButton.show()
 
   def onHideDisplacementChart(self, caller, event):
@@ -169,6 +169,7 @@ class SliceTrackerOverviewStep(SliceTrackerStep):
       else:
         self.currentResult = self.session.data.getApprovedOrLastResultForSeries(selectedSeries).name
         self.regResultsCollapsibleButton.show()
+        self.regResultsPlugin.setVisible(True)
         self.regResultsPlugin.onLayoutChanged()
       self.targetTablePlugin.currentTargets = self.currentResult.targets.approved if self.currentResult.approved \
         else self.currentResult.targets.bSpline

--- a/SliceTracker/SliceTrackerUtils/steps/plugins/charts.py
+++ b/SliceTracker/SliceTrackerUtils/steps/plugins/charts.py
@@ -203,7 +203,7 @@ class SliceTrackerDisplacementChartPlugin(SliceTrackerPlugin):
     approvedResults = sorted([r for r in self.session.data.registrationResults.values() if r.approved],
                              key=lambda r: r.seriesNumber)
     nonSelectedApprovedResults = filter(lambda x: x.seriesNumber != selectedSeriesNumber, approvedResults)
-    if len(nonSelectedApprovedResults) == 0:
+    if len(nonSelectedApprovedResults) == 0 or self.session.currentResult is None:
       return False
     return True
 

--- a/SliceTracker/SliceTrackerUtils/steps/plugins/results.py
+++ b/SliceTracker/SliceTrackerUtils/steps/plugins/results.py
@@ -134,7 +134,7 @@ class SliceTrackerRegistrationResultsPlugin(SliceTrackerPlugin):
     self.opacitySpinBox = qt.QDoubleSpinBox()
     self.opacitySpinBox.minimum = 0
     self.opacitySpinBox.maximum = 1.0
-    self.opacitySpinBox.value = 0
+    self.opacitySpinBox.value = 1
     self.opacitySpinBox.singleStep = 0.05
     self.opacitySliderPopup = ctk.ctkPopupWidget(self.opacitySpinBox)
     popupLayout = qt.QHBoxLayout(self.opacitySliderPopup)
@@ -143,7 +143,7 @@ class SliceTrackerRegistrationResultsPlugin(SliceTrackerPlugin):
     self.opacitySlider.orientation = qt.Qt.Horizontal
     self.opacitySlider.minimum = 0
     self.opacitySlider.maximum = 1.0
-    self.opacitySlider.value = 0
+    self.opacitySlider.value = 1
     self.opacitySlider.singleStep = 0.05
     popupLayout.addWidget(self.opacitySlider)
     self.opacitySliderPopup.verticalDirection = ctk.ctkBasePopupWidget.TopToBottom
@@ -247,6 +247,7 @@ class SliceTrackerRegistrationResultsPlugin(SliceTrackerPlugin):
       return
     self.onRegistrationResultSelected(self.currentResult.name)
     self.onOpacitySpinBoxChanged(self.opacitySpinBox.value)
+    self.sliceAnnotationHandler.setOldNewIndicatorAnnotationOpacity(self.opacitySpinBox.value)
 
   def onRegistrationButtonChecked(self, button):
     self.displayRegistrationResultsByType(button.name)
@@ -333,12 +334,13 @@ class SliceTrackerRegistrationResultsPlugin(SliceTrackerPlugin):
     if self.flickerCheckBox.checked:
       self.flickerCheckBox.checked = False
     self.rockTimer.start()
-    self.opacitySpinBox.value = 0.5 + numpy.sin(self.rockCount / 10.) / 2.
+    self.opacitySpinBox.value = 0.5 - numpy.sin(self.rockCount / 10.) / 2.
     self.rockCount += 1
 
   def stopRocking(self):
     self.rockTimer.stop()
     self.opacitySpinBox.value = 1.0
+    self.rockCount = 0
 
   def startFlickering(self):
     if self.rockCheckBox.checked:

--- a/SliceTracker/SliceTrackerUtils/steps/plugins/segmentation/automatic.py
+++ b/SliceTracker/SliceTrackerUtils/steps/plugins/segmentation/automatic.py
@@ -99,7 +99,7 @@ class SliceTrackerAutomaticSegmentationPlugin(SliceTrackerSegmentationPluginBase
     super(SliceTrackerAutomaticSegmentationPlugin, self).setup()
 
   def onActivation(self):
-    if self.getSetting("Use_Deep_Learning") == "true":
+    if self.getSetting("Use_Deep_Learning").lower() == "true":
       self.startSegmentation()
 
   def startSegmentation(self):

--- a/SliceTracker/SliceTrackerUtils/steps/segmentation.py
+++ b/SliceTracker/SliceTrackerUtils/steps/segmentation.py
@@ -214,6 +214,11 @@ class SliceTrackerSegmentationStep(SliceTrackerStep):
     result.setTargets(approvedRegistrationType, clone)
     result.volumes.fixed = fixedVolume
     result.labels.fixed = self.session.fixedLabel
+
+    if self.session.seriesTypeManager.isCoverProstate(self.session.currentResult.name) and \
+    self.session.data.getMostRecentApprovedCoverProstateRegistration() is not None:
+      self.session.data.getMostRecentApprovedCoverProstateRegistration().reject()
+
     result.approve(approvedRegistrationType)
 
   def _onAutomaticSegmentationStarted(self, caller, event):


### PR DESCRIPTION
Fixes issues found in #312.

- Fix bug where an upper case letter was causing errors using Deep Learning on Windows
- Fix bug where the lack of a current result was causing the displacement chart to crash when adding points
- Fix issue where the registration evaluation collapsible button had no contents in the overview step when clicking it
- Improved the "Rock" effect in the results plugin for consistency when using
- Fix the handling of multiple cover prostates, rejecting the first if a second is received
