### PR TITLE
ENH: handling situation regarding multiple Cover Prostate, no preop and modification of segmentation

### DIFF
--- a/SliceTracker/SliceTracker.py
+++ b/SliceTracker/SliceTracker.py
@@ -55,7 +55,7 @@ class SliceTrackerWidget(ModuleWidgetMixin, SliceTrackerConstants, ScriptedLoada
     self.session.removeEventObservers()
     self.session.addEventObserver(self.session.CloseCaseEvent, lambda caller, event: self.cleanup())
     self.session.addEventObserver(SlicerDevelopmentToolboxEvents.NewFileIndexedEvent, self.onNewFileIndexed)
-    self.demoMode = False
+    self.demoMode = self.getSetting("Demo_Mode", moduleName=self.moduleName)
 
   def enter(self):
     if not slicer.dicomDatabase:
@@ -175,6 +175,7 @@ class SliceTrackerWidget(ModuleWidgetMixin, SliceTrackerConstants, ScriptedLoada
     receivedFile = self.session.loadableList[callData][0] if callData else None
     if not self.session.data.usePreopData and self.patientWatchBox.sourceFile is None:
       self.patientWatchBox.sourceFile = receivedFile
+      self.patientWatchBox.setInformation("StudyDate", "NA")
     self.intraopWatchBox.sourceFile = receivedFile
 
   @vtk.calldata_type(vtk.VTK_STRING)

--- a/SliceTracker/SliceTracker.py
+++ b/SliceTracker/SliceTracker.py
@@ -55,7 +55,7 @@ class SliceTrackerWidget(ModuleWidgetMixin, SliceTrackerConstants, ScriptedLoada
     self.session.removeEventObservers()
     self.session.addEventObserver(self.session.CloseCaseEvent, lambda caller, event: self.cleanup())
     self.session.addEventObserver(SlicerDevelopmentToolboxEvents.NewFileIndexedEvent, self.onNewFileIndexed)
-    self.demoMode = self.getSetting("Demo_Mode", moduleName=self.moduleName)
+    self.demoMode = self.getSetting("Demo_Mode", moduleName=self.moduleName).lower() == 'true'
 
   def enter(self):
     if not slicer.dicomDatabase:
@@ -73,6 +73,7 @@ class SliceTrackerWidget(ModuleWidgetMixin, SliceTrackerConstants, ScriptedLoada
   def cleanup(self):
     ScriptedLoadableModuleWidget.cleanup(self)
     self.patientWatchBox.sourceFile = None
+    self.preopWatchBox.sourceFile = None
     self.intraopWatchBox.sourceFile = None
 
   def setup(self):
@@ -92,24 +93,33 @@ class SliceTrackerWidget(ModuleWidgetMixin, SliceTrackerConstants, ScriptedLoada
 
   def setupPatientWatchBox(self):
     WatchBoxAttribute.TRUNCATE_LENGTH = 20
-    self.patientWatchBoxInformation = [WatchBoxAttribute('PatientName', 'Name: ', DICOMTAGS.PATIENT_NAME, masked=self.demoMode),
-                                       WatchBoxAttribute('PatientID', 'PID: ', DICOMTAGS.PATIENT_ID, masked=self.demoMode),
-                                       WatchBoxAttribute('DOB', 'DOB: ', DICOMTAGS.PATIENT_BIRTH_DATE, masked=self.demoMode),
-                                       WatchBoxAttribute('StudyDate', 'Preop Date: ', DICOMTAGS.STUDY_DATE)]
-    self.patientWatchBox = DICOMBasedInformationWatchBox(self.patientWatchBoxInformation, title="Patient Information",
+    patientWatchBoxInformation = [WatchBoxAttribute('PatientName', "Patient's Name: ", DICOMTAGS.PATIENT_NAME,
+                                                    masked=self.demoMode),
+                                  WatchBoxAttribute('PatientID', 'Patient ID: ', DICOMTAGS.PATIENT_ID,
+                                                    masked=self.demoMode),
+                                  WatchBoxAttribute('DOB', "Patient's Birth Date: ", DICOMTAGS.PATIENT_BIRTH_DATE,
+                                                    masked=self.demoMode)]
+    self.patientWatchBox = DICOMBasedInformationWatchBox(patientWatchBoxInformation, title="Patient Information",
                                                          columns=2)
     self.layout.addWidget(self.patientWatchBox)
 
+    preopWatchBoxInformation = [WatchBoxAttribute('StudyDate', 'Study Date: ', DICOMTAGS.STUDY_DATE)]
+    self.preopWatchBox = DICOMBasedInformationWatchBox(preopWatchBoxInformation, title="Preop Information", columns=2)
+    self.layout.addWidget(self.preopWatchBox)
+
     intraopWatchBoxInformation = [WatchBoxAttribute('CurrentSeries', 'Current Series: ', [DICOMTAGS.SERIES_NUMBER,
                                                                                           DICOMTAGS.SERIES_DESCRIPTION]),
-                                  WatchBoxAttribute('StudyDate', 'Intraop Date: ', DICOMTAGS.STUDY_DATE)]
-    self.intraopWatchBox = DICOMBasedInformationWatchBox(intraopWatchBoxInformation, columns=2)
+                                  WatchBoxAttribute('StudyDate', 'Study Date: ', DICOMTAGS.STUDY_DATE)]
+    self.intraopWatchBox = DICOMBasedInformationWatchBox(intraopWatchBoxInformation, title="Intraop Information",
+                                                         columns=2)
     self.registrationDetailsButton = self.createButton("", icon=Icons.settings, styleSheet="border:none;",
                                                        maximumWidth=16)
     self.layout.addWidget(self.intraopWatchBox)
 
   def setupViewSettingGroupBox(self):
     iconSize = qt.QSize(24, 24)
+    self.infoButton = self.createButton("", icon=Icons.info, iconSize=iconSize, checkable=True,
+                                        toolTip="Display Patient/Study Information", checked=True)
     self.redOnlyLayoutButton = RedSliceLayoutButton()
     self.sideBySideLayoutButton = SideBySideLayoutButton()
     self.fourUpLayoutButton = FourUpLayoutButton()
@@ -122,7 +132,7 @@ class SliceTrackerWidget(ModuleWidgetMixin, SliceTrackerConstants, ScriptedLoada
                                                    toolTip="Display annotations", checked=True)
 
     viewSettingButtons = [self.redOnlyLayoutButton, self.sideBySideLayoutButton, self.fourUpLayoutButton,
-                          self.crosshairButton, self.wlEffectsToolButton, self.settingsButton,
+                          self.infoButton, self.crosshairButton, self.wlEffectsToolButton, self.settingsButton,
                           self.dicomConnectionTestButton]
 
     for step in self.session.steps:
@@ -145,6 +155,7 @@ class SliceTrackerWidget(ModuleWidgetMixin, SliceTrackerConstants, ScriptedLoada
     self.tabWidget.hideTabs()
 
   def setupConnections(self):
+    self.infoButton.connect('toggled(bool)', self.onShowInformationToggled)
     self.showAnnotationsButton.connect('toggled(bool)', self.onShowAnnotationsToggled)
 
   def setupSessionObservers(self):
@@ -157,10 +168,17 @@ class SliceTrackerWidget(ModuleWidgetMixin, SliceTrackerConstants, ScriptedLoada
 
   def onSuccessfulPreProcessing(self, caller, event):
     dicomFileName = self.logic.getFileList(self.session.preopDICOMDirectory)[0]
-    self.patientWatchBox.sourceFile = os.path.join(self.session.preopDICOMDirectory, dicomFileName)
+    filename = os.path.join(self.session.preopDICOMDirectory, dicomFileName)
+    self.patientWatchBox.sourceFile = filename
+    self.preopWatchBox.sourceFile = filename
 
   def onShowAnnotationsToggled(self, checked):
     allSliceAnnotations = self.sliceAnnotations[:]
+
+  def onShowInformationToggled(self, checked):
+    self.patientWatchBox.visible = checked
+    self.preopWatchBox.visible = checked
+    self.intraopWatchBox.visible = checked
 
   @vtk.calldata_type(vtk.VTK_STRING)
   def onNewFileIndexed(self, caller, event, callData):
@@ -175,7 +193,7 @@ class SliceTrackerWidget(ModuleWidgetMixin, SliceTrackerConstants, ScriptedLoada
     receivedFile = self.session.loadableList[callData][0] if callData else None
     if not self.session.data.usePreopData and self.patientWatchBox.sourceFile is None:
       self.patientWatchBox.sourceFile = receivedFile
-      self.patientWatchBox.setInformation("StudyDate", "NA")
+      self.preopWatchBox.setInformation("StudyDate", "NA")
     self.intraopWatchBox.sourceFile = receivedFile
 
   @vtk.calldata_type(vtk.VTK_STRING)

--- a/SliceTracker/SliceTracker.py
+++ b/SliceTracker/SliceTracker.py
@@ -249,7 +249,17 @@ class SliceTrackerTabWidget(qt.QTabWidget, ModuleWidgetMixin):
           self.session.previousStep = step
         step.active = False
     self.session.steps[index].active = True
+    self.updateSizes(index)
 
+  def updateSizes(self, index):
+    for i in range(self.count):
+      if i != index:
+        self.widget(i).setSizePolicy(qt.QSizePolicy.Ignored, qt.QSizePolicy.Ignored)
+
+    self.widget(index).setSizePolicy(qt.QSizePolicy.Preferred, qt.QSizePolicy.Preferred)
+    self.widget(index).resize(self.widget(index).minimumSizeHint)
+    self.resize(self.minimumSizeHint)
+    self.adjustSize()
 
 class SliceTrackerSlicelet(qt.QWidget, ModuleWidgetMixin):
 

--- a/SliceTracker/SliceTrackerUtils/steps/evaluation.py
+++ b/SliceTracker/SliceTrackerUtils/steps/evaluation.py
@@ -20,6 +20,7 @@ class SliceTrackerEvaluationStep(SliceTrackerStep):
 
   NAME = "Evaluation"
   LogicClass = SliceTrackerEvaluationStepLogic
+  LayoutClass = qt.QVBoxLayout
 
   def __init__(self):
     self.modulePath = os.path.dirname(slicer.util.modulePath(self.MODULE_NAME)).replace(".py", "")
@@ -27,9 +28,6 @@ class SliceTrackerEvaluationStep(SliceTrackerStep):
 
   def setup(self):
     super(SliceTrackerEvaluationStep, self).setup()
-    self.registrationEvaluationGroupBox = qt.QGroupBox()
-    self.registrationEvaluationGroupBoxLayout = qt.QGridLayout()
-    self.registrationEvaluationGroupBox.setLayout(self.registrationEvaluationGroupBoxLayout)
     self.setupRegistrationValidationButtons()
 
     self.regResultsPlugin = SliceTrackerRegistrationResultsPlugin()
@@ -50,12 +48,11 @@ class SliceTrackerEvaluationStep(SliceTrackerStep):
     self.displacementChartPlugin.addEventObserver(self.displacementChartPlugin.ShowEvent, self.omShowDisplacementChart)
     self.displacementChartPlugin.addEventObserver(self.displacementChartPlugin.HideEvent, self.onHideDisplacementChart)
 
-    self.registrationEvaluationGroupBoxLayout.addWidget(self.regResultsPlugin, 3, 0)
-    self.registrationEvaluationGroupBoxLayout.addWidget(self.targetTablePlugin, 4, 0)
-    self.registrationEvaluationGroupBoxLayout.addWidget(self.registrationEvaluationButtonsGroupBox, 5, 0)
-    self.registrationEvaluationGroupBoxLayout.addWidget(self.displacementChartPlugin.collapsibleButton, 6, 0)
-    self.registrationEvaluationGroupBoxLayout.setRowStretch(6, 1)
-    self.layout().addWidget(self.registrationEvaluationGroupBox)
+    self.layout().addWidget(self.regResultsPlugin)
+    self.layout().addWidget(self.targetTablePlugin)
+    self.layout().addWidget(self.registrationEvaluationButtonsGroupBox)
+    self.layout().addWidget(self.displacementChartPlugin.collapsibleButton)
+    self.layout().addStretch(1)
 
   def setupRegistrationValidationButtons(self):
     iconSize = qt.QSize(36, 36)

--- a/SliceTracker/SliceTrackerUtils/steps/evaluation.py
+++ b/SliceTracker/SliceTrackerUtils/steps/evaluation.py
@@ -98,7 +98,7 @@ class SliceTrackerEvaluationStep(SliceTrackerStep):
 
     if self.session.seriesTypeManager.isCoverProstate(self.session.currentResult.name) and \
     self.session.data.getMostRecentApprovedCoverProstateRegistration() is not None:
-      self.session.data.getMostRecentApprovedCoverProstateRegistration().reject()
+      self.session.data.getMostRecentApprovedCoverProstateRegistration().skip()
 
     self.currentResult.approve(registrationType=self.regResultsPlugin.registrationButtonGroup.checkedButton().name)
     # if self.ratingWindow.isRatingEnabled():

--- a/SliceTracker/SliceTrackerUtils/steps/overview.py
+++ b/SliceTracker/SliceTrackerUtils/steps/overview.py
@@ -42,6 +42,7 @@ class SliceTrackerOverviewStep(SliceTrackerStep):
 
   NAME = "Overview"
   LogicClass = SliceTrackerOverViewStepLogic
+  LayoutClass = qt.QVBoxLayout
 
   def __init__(self):
     super(SliceTrackerOverviewStep, self).__init__()
@@ -84,14 +85,14 @@ class SliceTrackerOverviewStep(SliceTrackerStep):
     self.displacementChartPlugin.addEventObserver(self.displacementChartPlugin.HideEvent, self.onHideDisplacementChart)
     self.displacementChartPlugin.collapsibleButton.hide()
 
-    self.layout().addWidget(self.caseManagerPlugin, 0, 0)
-    self.layout().addWidget(self.trainingPlugin, 1, 0)
-    self.layout().addWidget(self.targetTablePlugin, 2, 0)
+    self.layout().addWidget(self.caseManagerPlugin)
+    self.layout().addWidget(self.trainingPlugin)
+    self.layout().addWidget(self.targetTablePlugin)
     self.layout().addWidget(self.createHLayout([self.intraopSeriesSelector, self.changeSeriesTypeButton,
-                                                self.trackTargetsButton, self.skipIntraopSeriesButton]), 3, 0)
-    self.layout().addWidget(self.regResultsCollapsibleButton, 4, 0)
-    self.layout().addWidget(self.displacementChartPlugin.collapsibleButton, 5, 0)
-    # self.layout().setRowStretch(8, 1)
+                                                self.trackTargetsButton, self.skipIntraopSeriesButton]))
+    self.layout().addWidget(self.regResultsCollapsibleButton)
+    self.layout().addWidget(self.displacementChartPlugin.collapsibleButton)
+    self.layout().addStretch(1)
 
   def onShowDisplacementChart(self, caller, event):
     self.displacementChartPlugin.collapsibleButton.show()

--- a/SliceTracker/SliceTrackerUtils/steps/plugins/segmentation/manual.py
+++ b/SliceTracker/SliceTrackerUtils/steps/plugins/segmentation/manual.py
@@ -97,11 +97,11 @@ class SliceTrackerManualSegmentationPlugin(SliceTrackerSegmentationPluginBase):
     self.invokeEvent(self.SegmentationStartedEvent)
 
   def _preCheckExistingSegmentation(self):
-    if not slicer.util.confirmYesNoDisplay("The automatic segmentation will be overwritten. Do you want to proceed?",
-                                           windowTitle="SliceTracker"):
-      self.surfaceCutToLabelWidget.logic.stopQuickSegmentationMode(cancelled=True)
-      return False
-    return True
+    if slicer.util.confirmYesNoDisplay("The automatic segmentation will be overwritten. Do you want to proceed?",
+                                       windowTitle="SliceTracker"):
+      return True
+    self.surfaceCutToLabelWidget.deactivateQuickSegmentationMode(cancelled=True)
+    return False
 
   def _onSegmentationCanceled(self, caller, event):
     self.invokeEvent(self.SegmentationCanceledEvent)

--- a/SliceTracker/SliceTrackerUtils/steps/plugins/segmentation/manual.py
+++ b/SliceTracker/SliceTrackerUtils/steps/plugins/segmentation/manual.py
@@ -63,14 +63,12 @@ class SliceTrackerManualSegmentationPlugin(SliceTrackerSegmentationPluginBase):
     self.surfaceCutToLabelWidget.colorSpin.setValue(self.session.segmentedLabelValue)
     self.surfaceCutToLabelWidget.imageVolumeSelector.setCurrentNode(self.session.fixedVolume)
     self._addSurfaceCutEventObservers()
-    # if (self.session.data.usePreopData or self.session.retryMode) and self.getSetting("Use_Deep_Learning") == "false":
-    #   self.layoutManager.setLayout(constants.LAYOUT_FOUR_UP)
-    #   slicer.app.processEvents()
-    #   self.surfaceCutToLabelWidget.quickSegmentationButton.click()
+    if self.getSetting("Use_Deep_Learning").lower() == "false":
+      self.surfaceCutToLabelWidget.quickSegmentationButton.checked = True
 
   def onDeactivation(self):
     super(SliceTrackerManualSegmentationPlugin, self).onDeactivation()
-    self._removeSurfacCutEventObservers()
+    self._removeSurfaceCutEventObservers()
 
   def _addSurfaceCutEventObservers(self):
     self.surfaceCutToLabelWidget.addEventObserver(self.surfaceCutToLabelWidget.SegmentationStartedEvent,
@@ -80,7 +78,7 @@ class SliceTrackerManualSegmentationPlugin(SliceTrackerSegmentationPluginBase):
     self.surfaceCutToLabelWidget.addEventObserver(self.surfaceCutToLabelWidget.SegmentationFinishedEvent,
                                                   self._onSegmentationFinished)
 
-  def _removeSurfacCutEventObservers(self):
+  def _removeSurfaceCutEventObservers(self):
     self.surfaceCutToLabelWidget.removeEventObserver(self.surfaceCutToLabelWidget.SegmentationStartedEvent,
                                                      self._onSegmentationStarted)
     self.surfaceCutToLabelWidget.removeEventObserver(self.surfaceCutToLabelWidget.SegmentationCanceledEvent,
@@ -89,7 +87,7 @@ class SliceTrackerManualSegmentationPlugin(SliceTrackerSegmentationPluginBase):
                                                      self._onSegmentationFinished)
 
   def _onSegmentationStarted(self, caller, event):
-    if self.getSetting("Use_Deep_Learning") == "true":
+    if self.getSetting("Use_Deep_Learning").lower() == "true":
       if not self._preCheckExistingSegmentation():
         return
     self.setupFourUpView(self.session.fixedVolume)

--- a/SliceTracker/SliceTrackerUtils/steps/segmentation.py
+++ b/SliceTracker/SliceTrackerUtils/steps/segmentation.py
@@ -273,6 +273,7 @@ class SliceTrackerSegmentationStep(SliceTrackerStep):
     segmentationNode = surfaceCutToLabelWidget.segmentationNode
     map(lambda x: segmentationNode.RemoveSegment(x), surfaceCutToLabelWidget.getSegmentIDs())
     segmentationsLogic.ImportLabelmapToSegmentationNode(labelNode, segmentationNode)
+    surfaceCutToLabelWidget.configureSegmentVisibility()
 
     segmentIDs = surfaceCutToLabelWidget.getSegmentIDs()
     segmentationNode.GetSegmentation().GetSegment(segmentIDs[0]).SetName(surfaceCutToLabelWidget.SEGMENTATION_NAME)

--- a/SliceTracker/SliceTrackerUtils/steps/segmentation.py
+++ b/SliceTracker/SliceTrackerUtils/steps/segmentation.py
@@ -216,7 +216,7 @@ class SliceTrackerSegmentationStep(SliceTrackerStep):
 
     if self.session.seriesTypeManager.isCoverProstate(self.session.currentResult.name) and \
     self.session.data.getMostRecentApprovedCoverProstateRegistration() is not None:
-      self.session.data.getMostRecentApprovedCoverProstateRegistration().reject()
+      self.session.data.getMostRecentApprovedCoverProstateRegistration().skip()
 
     result.approve(approvedRegistrationType)
 

--- a/SliceTracker/SliceTrackerUtils/steps/segmentation.py
+++ b/SliceTracker/SliceTrackerUtils/steps/segmentation.py
@@ -37,6 +37,7 @@ class SliceTrackerSegmentationStep(SliceTrackerStep):
 
   NAME = "Segmentation"
   LogicClass = SliceTrackerSegmentationStepLogic
+  LayoutClass = qt.QVBoxLayout
 
   def __init__(self):
     super(SliceTrackerSegmentationStep, self).__init__()
@@ -48,6 +49,7 @@ class SliceTrackerSegmentationStep(SliceTrackerStep):
     self._setupTargetingPlugin()
     self._setupAutomaticSegmentationPlugin()
     self._setupNavigationButtons()
+    self.layout().addStretch(1)
 
   def _setupTargetingPlugin(self):
     self.targetingPlugin = SliceTrackerTargetingPlugin()

--- a/SliceTracker/SliceTrackerUtils/steps/segmentation.py
+++ b/SliceTracker/SliceTrackerUtils/steps/segmentation.py
@@ -266,6 +266,21 @@ class SliceTrackerSegmentationStep(SliceTrackerStep):
   @vtk.calldata_type(vtk.VTK_OBJECT)
   def _onAutomaticSegmentationFinished(self, caller, event, labelNode):
     self.manualSegmentationPlugin.enabled = True
+    surfaceCutToLabelWidget = self.manualSegmentationPlugin.surfaceCutToLabelWidget
+
+    segmentationsLogic = slicer.modules.segmentations.logic()
+
+    segmentationNode = surfaceCutToLabelWidget.segmentationNode
+    map(lambda x: segmentationNode.RemoveSegment(x), surfaceCutToLabelWidget.getSegmentIDs())
+    segmentationsLogic.ImportLabelmapToSegmentationNode(labelNode, segmentationNode)
+
+    segmentIDs = surfaceCutToLabelWidget.getSegmentIDs()
+    segmentationNode.GetSegmentation().GetSegment(segmentIDs[0]).SetName(surfaceCutToLabelWidget.SEGMENTATION_NAME)
+
+    surfaceCutToLabelWidget.imageVolume = self.session.currentSeriesVolume
+    surfaceCutToLabelWidget.labelVolume = labelNode
+
+    surfaceCutToLabelWidget.segmentEditorWidgetButton.enabled = True
     self._onSegmentationFinished(caller, event, labelNode)
 
   @vtk.calldata_type(vtk.VTK_OBJECT)

--- a/SliceTracker/SliceTrackerUtils/steps/segmentation.py
+++ b/SliceTracker/SliceTrackerUtils/steps/segmentation.py
@@ -45,10 +45,13 @@ class SliceTrackerSegmentationStep(SliceTrackerStep):
 
   def setup(self):
     super(SliceTrackerSegmentationStep, self).setup()
-    self._setupManualSegmentationPlugin()
     self._setupTargetingPlugin()
+    self._setupManualSegmentationPlugin()
     self._setupAutomaticSegmentationPlugin()
     self._setupNavigationButtons()
+    self.layout().addWidget(self.manualSegmentationPlugin)
+    self.layout().addWidget(self.createHLayout([self.backButton, self.finishStepButton]))
+    self.layout().addWidget(self.targetingPlugin)
     self.layout().addStretch(1)
 
   def _setupTargetingPlugin(self):
@@ -56,7 +59,6 @@ class SliceTrackerSegmentationStep(SliceTrackerStep):
     self.targetingPlugin.addEventObserver(self.targetingPlugin.TargetingStartedEvent, self._onTargetingStarted)
     self.targetingPlugin.addEventObserver(self.targetingPlugin.TargetingFinishedEvent, self._onTargetingFinished)
     self.addPlugin(self.targetingPlugin)
-    self.layout().addWidget(self.targetingPlugin)
 
   def _setupManualSegmentationPlugin(self):
     self.manualSegmentationPlugin = SliceTrackerManualSegmentationPlugin()
@@ -67,7 +69,6 @@ class SliceTrackerSegmentationStep(SliceTrackerStep):
     self.manualSegmentationPlugin.addEventObserver(self.manualSegmentationPlugin.SegmentationFinishedEvent,
                                                    self._onSegmentationFinished)
     self.addPlugin(self.manualSegmentationPlugin)
-    self.layout().addWidget(self.manualSegmentationPlugin)
 
   def _setupAutomaticSegmentationPlugin(self):
     self.automaticSegmentationPlugin = SliceTrackerAutomaticSegmentationPlugin()
@@ -84,8 +85,7 @@ class SliceTrackerSegmentationStep(SliceTrackerStep):
     self.backButton = self.createButton("", icon=Icons.back, iconSize=iconSize,
                                         toolTip="Return to last step")
     self.finishStepButton = self.createButton("", icon=Icons.start, iconSize=iconSize,
-                                              toolTip="Run Registration")
-    self.layout().addWidget(self.createHLayout([self.backButton, self.finishStepButton]))
+                                              toolTip="Run Registration/Finish Step")
 
   def setupConnections(self):
     super(SliceTrackerSegmentationStep, self).setupConnections()

--- a/SliceTracker/SurfaceCutToLabel.py
+++ b/SliceTracker/SurfaceCutToLabel.py
@@ -39,9 +39,17 @@ class SurfaceCutToLabelWidget(ModuleWidgetMixin, ScriptedLoadableModuleWidget):
   def imageVolume(self):
     return self.imageVolumeSelector.currentNode()
 
+  @imageVolume.setter
+  def imageVolume(self, volume):
+    self.imageVolumeSelector.setCurrentNode(volume)
+
   @property
   def labelVolume(self):
     return self.labelMapSelector.currentNode()
+
+  @labelVolume.setter
+  def labelVolume(self, volume):
+    return self.labelMapSelector.setCurrentNode(volume)
 
   @property
   def segmentationNode(self):
@@ -64,9 +72,9 @@ class SurfaceCutToLabelWidget(ModuleWidgetMixin, ScriptedLoadableModuleWidget):
     if not displayNode:
       displayNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSegmentationDisplayNode")
       self._segmentationNode.SetAndObserveDisplayNodeID(displayNode.GetID())
-    map(lambda x: displayNode.SetSegmentVisibility(x, False), self._getSegmentIDs())
+    map(lambda x: displayNode.SetSegmentVisibility(x, False), self.getSegmentIDs())
 
-  def _getSegmentIDs(self):
+  def getSegmentIDs(self):
     segmentIDs = vtk.vtkStringArray()
     self._segmentationNode.GetSegmentation().GetSegmentIDs(segmentIDs)
     return [segmentIDs.GetValue(idx) for idx in range(segmentIDs.GetNumberOfValues())]
@@ -74,7 +82,7 @@ class SurfaceCutToLabelWidget(ModuleWidgetMixin, ScriptedLoadableModuleWidget):
   @segmentationNode.setter
   def segmentationNode(self, node):
     self._segmentationNode = node
-    if not any(segmentID == self.SEGMENTATION_NAME for segmentID in self._getSegmentIDs()):
+    if not any(segmentID == self.SEGMENTATION_NAME for segmentID in self.getSegmentIDs()):
       self._addInitialSegment()
     self._configureSegmentVisibility()
 


### PR DESCRIPTION
- targets placed in first cover prostate did not show up in intraop
  targeting table nor were those targets visible with the correct
  glyphs
- moved preop date outside of general patient information and setting to NA if none available
- watchbox information hideable
- tab height gets resized to current content
- entering quick mode segmentation mode immediately if deep learning is disabled 
- modification of deep learning segmentation enabled

addresses #312

fixes #283 