### PR TITLE
BUG: Surface Cut used without having an active segmentation (issue #338)

### DIFF
--- a/SliceTracker/SliceTrackerUtils/session.py
+++ b/SliceTracker/SliceTrackerUtils/session.py
@@ -1069,7 +1069,7 @@ class PreopDataHandler(PreprocessedDataHandlerBase):
         break
 
   def loadT2Label(self):
-    if self.data.initialLabel:
+    if self.data.initialLabel and self.data.initialLabel.GetScene() is not None:
       return True
     mostRecentFilename = self.getMostRecentWholeGlandSegmentation(self.preopSegmentationPath)
     success = False
@@ -1081,7 +1081,7 @@ class PreopDataHandler(PreprocessedDataHandlerBase):
     return success
 
   def loadPreopVolume(self):
-    if self.data.initialVolume:
+    if self.data.initialVolume and self.data.initialVolume.GetScene() is not None:
       return True
     success, self.data.initialVolume = slicer.util.loadVolume(self.preopImagePath, returnNode=True)
     if success:
@@ -1089,7 +1089,7 @@ class PreopDataHandler(PreprocessedDataHandlerBase):
     return success
 
   def loadPreopTargets(self):
-    if self.data.initialTargets:
+    if self.data.initialTargets and self.data.initialTargets.GetScene() is not None:
       return True
     if not os.path.exists(self.data.initialTargetsPath):
       return False


### PR DESCRIPTION
* also checking preop data not only for being valid variables in class,
  but also for being assigned to the mrmlScene

fixes #338